### PR TITLE
fix issues with fresh npm and from-source installs

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -26,11 +26,11 @@ const path = require("path");
 
 const compiler = require("./src/compiler");
 
+const version = require("./package").version;
+
 const argv = require("yargs")
-    .version(function() {
-        return require("./package").version;
-    })
-    .usage("jaz -s [input source circuit file] -o [output definition circuit file]")
+    .version(version)
+    .usage("circom -s [input source circuit file] -o [output definition circuit file]")
     .alias("s", "source")
     .alias("o", "output")
     .require(["s","o"])
@@ -40,7 +40,7 @@ const argv = require("yargs")
     This program comes with ABSOLUTELY NO WARRANTY;
     This is free software, and you are welcome to redistribute it
     under certain conditions; see the COPYING file in the official
-    repo directory at  https://github.com/iden3/jaz `)
+    repo directory at  https://github.com/iden3/circom `)
     .argv;
 
 const fullFileName = path.resolve(process.cwd(), argv.source);

--- a/package.json
+++ b/package.json
@@ -30,13 +30,14 @@
   },
   "dependencies": {
     "big-integer": "^1.6.32",
-    "optimist": "^0.6.1"
+    "optimist": "^0.6.1",
+    "yargs": "^12.0.2"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.0.1",
     "eslint-plugin-mocha": "^5.0.0",
     "jison": "^0.4.18",
-    "zksnark": "0.0.6"
+    "zksnark": "0.0.10"
   }
 }


### PR DESCRIPTION
I'm trying this out and ran into some minor issues; let me know if these fixes are helpful.

After installing by npm install -g circom:

```
Error: Cannot find module 'yargs'
```

While installing from source:

```
npm ERR! notarget No matching version found for zksnark@0.0.6
```

After installing from source:

```
YError: Invalid first argument. Expected boolean or string but received function.
    at argumentTypeError (circom/node_modules/yargs/lib/argsert.js:65:9)
    at parsed.optional.forEach (circom/node_modules/yargs/lib/argsert.js:47:39)
    at Array.forEach (<anonymous>)
    at argsert (circom/node_modules/yargs/lib/argsert.js:42:21)
    at Object.version (circom/node_modules/yargs/yargs.js:778:5)
    at Object.<anonymous> (circom/cli.js:30:6)
   ...
```

Changes:
- In package.json I added yargs and updated the version of zsnarks to the latest, 0.0.10
- Cli.js no longer outputs "jaz" to console
- Cli.js imports the version number and passes it instead of using an anonymous function, which had confused the yargs module