### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install -g circom
 The circuit is compiled with the following command:
 
 ```
-circom -s mycircuit.circom -o mycircuit.json
+circom mycircuit.circom -o mycircuit.json
 ```
 
 The resulting output ( `mycircuit.json` ) can be used in the [zksnarks JavaScript library](https://github.com/iden3/zksnark).


### PR DESCRIPTION
Problem: -s option is not required and returns an error when used
```
 circom -s ./mycircuit.circom -o ./mycircuit.json
ENOENT: no such file or directory, open '/Users/user/js/jsbench/circuit.circom'
```

Solution:
remove -s option in the README file