### PR TITLE
Add error location to non-matching constraint

### DIFF
--- a/src/gencode.js
+++ b/src/gencode.js
@@ -422,7 +422,7 @@ function genConstrain(ctx, ast) {
     if (ctx.error) return;
     const b = gen(ctx, ast.values[1]);
     if (ctx.error) return;
-    return `ctx.assert(${a}, ${b})`;
+    return `ctx.assert(${a}, ${b}, '${ctx.fileName}:${ast.first_line}:${ast.first_column + 1}')`;
 }
 
 function genSignalAssignConstrain(ctx, ast) {


### PR DESCRIPTION
Should be merged after https://github.com/iden3/snarkjs/pull/30

Error location is very handy.
```bash
circom && snarkjs setup --protocol groth && snarkjs generateverifier && snarkjs calculatewitness && snarkjs proof && snarkjs verify && snarkjs info
```

>Error: Constraint doesn't match: 66988482986943799312951692319852916441223464438865622325288249495563041273 != 66988482986943797804311918746082161243771806775581332108251452349691723776 **(/Users/k06a/Projects/snark1/circuit.circom:26:5)**
    at RTCtx.assert (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:230:19)
    at Object.__f [as hello] (eval at Circuit (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/circuit.js:46:33), <anonymous>:4:9)
    at RTCtx.triggerComponent (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:126:41)
    at callComponents.map (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:167:51)
    at Array.map (<anonymous>)
    at RTCtx.setSignalFullName (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:166:24)
    at RTCtx.setSignal (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:104:14)
    at /Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:50:17
    at iterateSelector (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:31:20)
    at calculateWitness (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:48:9)
ERROR: Error: Constraint doesn't match: 66988482986943799312951692319852916441223464438865622325288249495563041273 != 66988482986943797804311918746082161243771806775581332108251452349691723776 (/Users/k06a/Projects/snark1/circuit.circom:26:5)