### PR TITLE
feature: add progress info for loop in main component

### DIFF
--- a/src/construction_phase.js
+++ b/src/construction_phase.js
@@ -795,7 +795,18 @@ function execLoop(ctx, ast) {
         return;
     }
 
+    let loopIdx = 0;
+    let isTopLevelLoop = !ctx.hasParentLoop;
+    ctx.hasParentLoop = true;
     while ((! ctx.F.isZero(v.v[0].v))&&(!ctx.returnValue)) {
+        if (ctx.verbose && ctx.main && isTopLevelLoop) {
+            let logStr =  `main loop: loopIdx ${loopIdx}`;
+            if (ast.condition.type === 'OP') {
+                logStr += ` condition ${ast.condition.values.map(item => item.name).join(ast.condition.op)}`;
+            }
+            logStr += ` at ${ctx.fileName}:${ast.first_line}`;
+            console.log(logStr)
+        }
         exec(ctx, ast.body);
         if (ctx.error) return;
 
@@ -808,6 +819,10 @@ function execLoop(ctx, ast) {
         if (ctx.error) return;
         if (v.s[0] != 1) return ctx.throwError(ast.condition, "Condition in loop cannot be an array");
         if (v.v[0].t != "N") return ctx.throwError(ast.condition, "Condition result not a number");
+        loopIdx++;
+    }
+    if (isTopLevelLoop) {
+        ctx.hasParentLoop = null;
     }
 }
 


### PR DESCRIPTION
after adding these lines, circom can output some progress info when compiling the main component, which is quite helpful for compling huge circuits.

```
main loop: loopIdx 0 condition i<nTxs at /home/ubuntu/fluidex/circuits/src/block.circom:45
main loop: loopIdx 1 condition i<nTxs at /home/ubuntu/fluidex/circuits/src/block.circom:45
Constraints: 10000
Constraints: 20000
Constraints: 30000
Constraints: 40000
Constraints: 50000
Constraints: 60000
Constraints: 70000
Constraints: 80000
Constraints: 90000
main loop: loopIdx 0 condition i<nTxs at /home/ubuntu/fluidex/circuits/src/block.circom:61
main loop: loopIdx 1 condition i<nTxs at /home/ubuntu/fluidex/circuits/src/block.circom:61
main loop: loopIdx 0 condition i<nTxs at /home/ubuntu/fluidex/circuits/src/block.circom:94
Constraints: 100000
Constraints: 110000
Constraints: 120000
Constraints: 130000
Constraints: 140000
Constraints: 150000
Constraints: 160000
```