### PR TITLE
feat: Support passing filenames in options for each output type

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,6 @@ const fs = require("fs");
 const path = require("path");
 const Scalar = require("ffjavascript").Scalar;
 const stringifyBigInts = require("ffjavascript").utils.stringifyBigInts;
-const fastFile = require("fastfile");
 
 const compiler = require("./src/compiler");
 
@@ -87,15 +86,15 @@ async function run() {
     options.sanityCheck = argv.sanitycheck;
 
     if (argv.csource) {
-        options.cSourceFile = await fastFile.createOverride(cSourceName);
+        options.cSourceFileName = cSourceName;
         const noExt = cSourceName.substr(0, cSourceName.lastIndexOf(".")) || cSourceName;
-        options.dataFile = await fastFile.createOverride(noExt+".dat");
+        options.dataFileName = noExt+".dat";
     }
     if (argv.wasm) {
-        options.wasmFile = await fastFile.createOverride(wasmName);
+        options.wasmFileName = wasmName;
     }
     if (argv.wat) {
-        options.watFile = await fastFile.createOverride(watName);
+        options.watFileName = watName;
     }
     if (argv.r1cs) {
         options.r1csFileName = r1csName;
@@ -119,10 +118,6 @@ async function run() {
 
     await compiler(fullFileName, options);
 
-    if (options.cSourceFile) await options.cSourceFile.close();
-    if (options.dataFile) await options.dataFile.close();
-    if (options.wasmFile) await options.wasmFile.close();
-    if (options.watFile) await options.watFile.close();
     let symDone = false;
     if (options.symWriteStream) {
         options.symWriteStream.on("finish", () => {

--- a/ports/c/tester.js
+++ b/ports/c/tester.js
@@ -13,7 +13,6 @@ const utils = require("../../src/utils");
 const loadR1cs = require("r1csfile").load;
 const ZqField = require("ffjavascript").ZqField;
 const buildZqField = require("ffiasm").buildZqField;
-const fastFile = require("fastfile");
 
 const {stringifyBigInts, unstringifyBigInts } = require("ffjavascript").utils;
 
@@ -30,16 +29,13 @@ async function  c_tester(circomFile, _options) {
     const baseName = path.basename(circomFile, ".circom");
     const options = Object.assign({}, _options);
 
-    options.cSourceFile = await fastFile.createOverride(path.join(dir.path, baseName + ".cpp"));
-    options.dataFile = await fastFile.createOverride(path.join(dir.path, baseName + ".dat"));
+    options.cSourceFileName = path.join(dir.path, baseName + ".cpp");
+    options.dataFileName = path.join(dir.path, baseName + ".dat");
     options.symWriteStream = fs.createWriteStream(path.join(dir.path, baseName + ".sym"));
     options.r1csFileName = path.join(dir.path, baseName + ".r1cs");
 
     options.p = options.p || Scalar.fromString("21888242871839275222246405745257275088548364400416034343698204186575808495617");
     await compiler(circomFile, options);
-
-    await options.cSourceFile.close();
-    await options.dataFile.close();
 
     const source = await buildZqField(options.p, "Fr");
 

--- a/ports/wasm/tester.js
+++ b/ports/wasm/tester.js
@@ -9,7 +9,6 @@ const compiler = require("../../src/compiler");
 const utils = require("../../src/utils");
 const loadR1cs = require("r1csfile").load;
 const ZqField = require("ffjavascript").ZqField;
-const fastFile = require("fastfile");
 
 const WitnessCalculatorBuilder = require("circom_runtime").WitnessCalculatorBuilder;
 
@@ -25,14 +24,12 @@ async function  wasm_tester(circomFile, _options) {
     const baseName = path.basename(circomFile, ".circom");
     const options = Object.assign({}, _options);
 
-    options.wasmFile = await fastFile.createOverride(path.join(dir.path, baseName + ".wasm"));
+    options.wasmFileName = path.join(dir.path, baseName + ".wasm");
 
     options.symWriteStream = fs.createWriteStream(path.join(dir.path, baseName + ".sym"));
     options.r1csFileName = path.join(dir.path, baseName + ".r1cs");
 
     await compiler(circomFile, options);
-
-    await options.wasmFile.close();
 
     const wasm = await fs.promises.readFile(path.join(dir.path, baseName + ".wasm"));
 

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -29,6 +29,7 @@ const buildR1cs = require("./r1csfile").buildR1cs;
 const BigArray = require("./bigarray");
 const buildSyms = require("./buildsyms");
 const {performance} = require("perf_hooks");
+const fastFile = require("fastfile");
 
 module.exports = compile;
 const measures = {};
@@ -129,6 +130,14 @@ async function compile(srcFile, options) {
 
     delete ctx.constraints;  // Liberate memory.
 
+    if (options.cSourceFileName) {
+        options.cSourceFile = await fastFile.createOverride(options.cSourceFileName);
+    }
+
+    if (options.dataFileName) {
+        options.dataFile = await fastFile.createOverride(options.dataFileName);
+    }
+
     if (options.cSourceFile) {
         if (ctx.verbose) console.log("Generating c...");
         measures.generateC = -performance.now();
@@ -139,6 +148,14 @@ async function compile(srcFile, options) {
     }
 
     if (ctx.error) throw(ctx.error);
+
+    if (options.wasmFileName) {
+        options.wasmFile = await fastFile.createOverride(options.wasmFileName);
+    }
+
+    if (options.watFileName) {
+        options.watFile = await fastFile.createOverride(options.watFileName);
+    }
 
     if ((options.wasmFile)||(options.watFile)) {
         if (ctx.verbose) console.log("Generating wasm...");
@@ -173,6 +190,11 @@ async function compile(srcFile, options) {
             console.log(mStr + ": " + ms2String(mValue));
         }
     }
+
+    if (options.cSourceFile) await options.cSourceFile.close();
+    if (options.dataFile) await options.dataFile.close();
+    if (options.wasmFile) await options.wasmFile.close();
+    if (options.watFile) await options.watFile.close();
 }
 
 


### PR DESCRIPTION
This adds `cSourceFileName`, `dataFileName`, `wasmFileName`, and `watFileName` to the Compiler options. It also moves the fastfile creation into the Compiler itself (instead of the CLI) and will call fastfile only if the new *FileName options are passed.

This makes it easier to wrap or combine the Circom compiler with other tooling without requiring the integrations to generate their own fastfiles.

Additionally, the `close()` functions can be called at the end of the compiler because the values are invalid to use (specifically a MemFile) if you try to use them without closing.