### PR TITLE
R1cs map is an array of 64bit elements not 32

### DIFF
--- a/constraint_writers/src/r1cs_writer.rs
+++ b/constraint_writers/src/r1cs_writer.rs
@@ -265,7 +265,7 @@ impl SignalSection {
     where
         T: AsRef<[u8]>,
     {
-        let (bytes, size) = into_format(bytes.as_ref(), 4);
+        let (bytes, size) = into_format(bytes.as_ref(), 8);
         self.size += size;
         self.writer.write_all(&bytes).map_err(|_err| {})?;
         self.writer.flush().map_err(|_err| {})


### PR DESCRIPTION
Map section in r1cs file is an array of 64 bits elements not 32 bits. 

This incompatibility breaks `snarkjs r1cs export json` and `snarkjs r1cs printconstraints`

This PR fix it. 