### PR TITLE
Support process substitution for circuit input

### DIFF
--- a/circom/src/input_user.rs
+++ b/circom/src/input_user.rs
@@ -185,11 +185,13 @@ mod input_processing {
     use ansi_term::Colour;
     use clap::{App, Arg, ArgMatches};
     use std::path::{Path, PathBuf};
+    use std::fs::File;
 
     pub fn get_input(matches: &ArgMatches) -> Result<PathBuf, ()> {
-        let route = Path::new(matches.value_of("input").unwrap()).to_path_buf();
-        if route.is_file() {
-            Result::Ok(route)
+        let route = Path::new(matches.value_of("input").unwrap());
+        let f = File::open(route);
+        if f.is_ok() {
+            Result::Ok(route.to_path_buf())
         } else {
             Result::Err(println!("{}", Colour::Red.paint("invalid input file")))
         }


### PR DESCRIPTION
The input file's validity is currently tested using `Path::is_file`, whose documentation [specifically mentions](https://doc.rust-lang.org/std/path/struct.Path.html#see-also-3) that it's preferred to use `File::open` instead, when simply confirming that a file is readable, as otherwise you accidentally prohibit important OS-level functionality like [Process Substitution](https://tldp.org/LDP/abs/html/process-sub.html).

A simplistic example of convenience that this enables is:
```
circom <(echo "pragma circom 2.0.0; include \"$(readlink -f circomlib/circuits/sha256/sha256.circom)\"; component main = Sha256(1024);")
```