### PR TITLE
Use full file name, not stem, to build code output paths

### DIFF
--- a/circom/src/input_user.rs
+++ b/circom/src/input_user.rs
@@ -46,10 +46,11 @@ impl Input {
         use input_processing::SimplificationStyle;
         let matches = input_processing::view();
         let input = input_processing::get_input(&matches)?;
-        let file_name = input.file_stem().unwrap().to_str().unwrap().to_string();
+        let file_name = input.file_name().unwrap().to_str().unwrap().to_string();
+        let file_stem = input.file_stem().unwrap().to_str().unwrap().to_string();
         let output_path = input_processing::get_output_path(&matches)?;
-        let output_c_path = Input::build_folder(&output_path, &file_name, CPP);
-        let output_js_path = Input::build_folder(&output_path, &file_name, JS);
+        let output_c_path = Input::build_folder(&output_path, &file_stem, CPP);
+        let output_js_path = Input::build_folder(&output_path, &file_stem, JS);
         let o_style = input_processing::get_simplification_style(&matches)?;
         Result::Ok(Input {
             field: P_0,


### PR DESCRIPTION
This change fixes #21, which occurs because [`PathBuf::file_stem`](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.file_stem) is being used to generate file names, but the generation of those file names uses [`PathBuf::set_extension`](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.set_extension), which replaces an "extension" if one seems to exist after the original extension is removed.

Presumably, the original thinking was that `set_extension` would just be *adding* an extension, since the existing one was being removed by `file_stem`.

This breaks down if the input filename contains a dot other than for its extension, as when the file stem is used, the final dot-separated segment of the file name starts to be treated as its "extension".

`/tmp/test.circom` => `/tmp/test` => `/tmp/test.wasm`
`/tmp/test.foo.circom` => `/tmp/test.foo` => `/tmp/test.wasm`