### PR TITLE
Faster `merge_code` implementation in code generators

### DIFF
--- a/code_producers/src/c_elements/c_code_generator.rs
+++ b/code_producers/src/c_elements/c_code_generator.rs
@@ -375,7 +375,7 @@ pub fn build_conditional(
 }
 
 pub fn merge_code(instructions: Vec<String>) -> String {
-    let mut code = format!("{}\n", instructions.join("\n"));
+    let code = format!("{}\n", instructions.join("\n"));
     code
 }
 

--- a/code_producers/src/c_elements/c_code_generator.rs
+++ b/code_producers/src/c_elements/c_code_generator.rs
@@ -375,10 +375,7 @@ pub fn build_conditional(
 }
 
 pub fn merge_code(instructions: Vec<String>) -> String {
-    let mut code = "".to_string();
-    for instruction in instructions {
-        code = format!("{}{}\n", code, instruction);
-    }
+    let mut code = format!("{}\n", instructions.join("\n"));
     code
 }
 

--- a/code_producers/src/wasm_elements/wasm_code_generator.rs
+++ b/code_producers/src/wasm_elements/wasm_code_generator.rs
@@ -23,7 +23,7 @@ pub fn wasm_hexa(nbytes: usize, num: &BigInt) -> String {
 }
 
 pub fn merge_code(instructions: Vec<String>) -> String {
-    let mut code = format!("{}\n", instructions.join("\n"));
+    let code = format!("{}\n", instructions.join("\n"));
     code
 }
 

--- a/code_producers/src/wasm_elements/wasm_code_generator.rs
+++ b/code_producers/src/wasm_elements/wasm_code_generator.rs
@@ -23,10 +23,7 @@ pub fn wasm_hexa(nbytes: usize, num: &BigInt) -> String {
 }
 
 pub fn merge_code(instructions: Vec<String>) -> String {
-    let mut code = "".to_string();
-    for instruction in instructions {
-        code = format!("{}{}\n", code, instruction);
-    }
+    let mut code = format!("{}\n", instructions.join("\n"));
     code
 }
 


### PR DESCRIPTION
Hi, I was playing around with building a WASM port for Circom 2.0. I noticed though that the slowest part by far was the `merge_code` step (it would hang for nearly 30 seconds before finishing). 

The current implementation is very allocation-heavy as it repeatedly re-allocates and copies strings. Rust 1.3.0 and later support a native Vec.join implementation which will more intelligently allocate a single buffer and copy from the strings in between. 

