### PR TITLE
fix: Print errors to stderr

### DIFF
--- a/circom/src/execution_user.rs
+++ b/circom/src/execution_user.rs
@@ -53,7 +53,7 @@ fn generate_output_r1cs(file: &str, exporter: &dyn ConstraintExporter) -> Result
         println!("{} {}", Colour::Green.paint("Written successfully:"), file);
         Result::Ok(())
     } else {
-        println!("{}", Colour::Red.paint("Could not write the output in the given path"));
+        eprintln!("{}", Colour::Red.paint("Could not write the output in the given path"));
         Result::Err(())
     }
 }
@@ -63,7 +63,7 @@ fn generate_output_sym(file: &str, exporter: &dyn ConstraintExporter) -> Result<
         println!("{} {}", Colour::Green.paint("Written successfully:"), file);
         Result::Ok(())
     } else {
-        println!("{}", Colour::Red.paint("Could not write the output in the given path"));
+        eprintln!("{}", Colour::Red.paint("Could not write the output in the given path"));
         Result::Err(())
     }
 }
@@ -76,7 +76,7 @@ fn generate_json_constraints(
         println!("{} {}", Colour::Green.paint("Constraints written in:"), debug.json_constraints);
         Result::Ok(())
     } else {
-        println!("{}", Colour::Red.paint("Could not write the output in the given path"));
+        eprintln!("{}", Colour::Red.paint("Could not write the output in the given path"));
         Result::Err(())
     }
 }

--- a/circom/src/input_user.rs
+++ b/circom/src/input_user.rs
@@ -196,7 +196,7 @@ mod input_processing {
         if route.is_file() {
             Result::Ok(route)
         } else {
-            Result::Err(println!("{}", Colour::Red.paint("invalid input file")))
+            Result::Err(eprintln!("{}", Colour::Red.paint("invalid input file")))
         }
     }
 
@@ -205,7 +205,7 @@ mod input_processing {
         if route.is_dir() {
             Result::Ok(route)
         } else {
-            Result::Err(println!("{}", Colour::Red.paint("invalid output path")))
+            Result::Err(eprintln!("{}", Colour::Red.paint("invalid output path")))
         }
     }
 
@@ -228,7 +228,7 @@ mod input_processing {
             (_, true, _, _) => Ok(SimplificationStyle::O1),
             (_, _, true, Ok(no_rounds)) => Ok(SimplificationStyle::O2(no_rounds)),
             (false, false, false, _) => Ok(SimplificationStyle::O1),
-            _ => Result::Err(println!("{}", Colour::Red.paint("invalid number of rounds")))
+            _ => Result::Err(eprintln!("{}", Colour::Red.paint("invalid number of rounds")))
         }
     }
 

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -12,7 +12,7 @@ use input_user::Input;
 fn main() {
     let result = start();
     if result.is_err() {
-        println!("{}", Colour::Red.paint("previous errors were found"));
+        eprintln!("{}", Colour::Red.paint("previous errors were found"));
     } else {
         println!("{}", Colour::Green.paint("Everything went okay, circom safe"));
     }

--- a/code_producers/src/wasm_elements/wasm_code_generator.rs
+++ b/code_producers/src/wasm_elements/wasm_code_generator.rs
@@ -1519,7 +1519,7 @@ mod tests {
                 }
             }
         } else {
-            println!("NO FILE FOUND");
+            eprintln!("NO FILE FOUND");
         }
         instructions
     }
@@ -1527,7 +1527,7 @@ mod tests {
     /*
         let bytes = empty.read_line(&mut buffer)?;
         if bytes == 0 {
-            println!("EOF reached");
+            eprintln!("EOF reached");
         }
     */
     fn write_block(writer: &mut BufWriter<File>, code: Vec<WasmInstruction>) {


### PR DESCRIPTION
While trying to process the logs of circom2, I found that you don't actually write errors to stderr, but instead print them in red on stdout.

This changes the "error" `println` calls to `eprintln` to print on stderr.