### PR TITLE
fix: Use a custom normalize_path to resolve duplicate symbol problem

### DIFF
--- a/parser/src/include_logic.rs
+++ b/parser/src/include_logic.rs
@@ -1,7 +1,36 @@
-use super::errors::FileOsError;
 use program_structure::error_definition::Report;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Component, PathBuf};
+
+// Replacement for std::fs::canonicalize that doesn't verify the path exists
+// Plucked from https://github.com/rust-lang/cargo/blob/fede83ccf973457de319ba6fa0e36ead454d2e20/src/cargo/util/paths.rs#L61
+// Advice from https://www.reddit.com/r/rust/comments/hkkquy/comment/fwtw53s/?utm_source=share&utm_medium=web2x&context=3
+fn normalize_path(path: &PathBuf) -> PathBuf {
+    let mut components = path.components().peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {
+                ret.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+        }
+    }
+    ret
+}
 
 pub struct FileStack {
     current_location: PathBuf,
@@ -19,9 +48,9 @@ impl FileStack {
     pub fn add_include(f_stack: &mut FileStack, path: String) -> Result<(), Report> {
         let mut crr = f_stack.current_location.clone();
         crr.push(path.clone());
-        let path = std::fs::canonicalize(crr)
-            .map_err(|_| FileOsError { path: path.clone() })
-            .map_err(|e| FileOsError::produce_report(e))?;
+        // Replaced `std::fs::canonicalize` with a custom `normalize_path` function.
+        // No existence testing in wasm
+        let path = normalize_path(&crr);
         if !f_stack.black_paths.contains(&path) {
             f_stack.stack.push(path);
         }


### PR DESCRIPTION
This PR helps to better support rust->wasm compilation of the circom compiler. I believe the wasm target doesn't support `std::fs::canonicalize` but @antimatter15 can probably provide more context on his change.

This is currently a draft because I want to discuss how we can handle the "file existence" check that `std::fs::canonicalize` was providing. Is there a better way or place to check for file existence that will work in rust & wasm?