### PR TITLE
Fix compiler panic on exit modified variables not in env

### DIFF
--- a/type_analysis/src/analyzers/unknown_known_analysis.rs
+++ b/type_analysis/src/analyzers/unknown_known_analysis.rs
@@ -213,8 +213,10 @@ fn analyze(stmt: &Statement, entry_information: EntryInformation) -> ExitInforma
 
             if tag_out == Unknown{
                 for var in &exit.modified_variables{
-                    let value = environment.get_mut_variable_or_break(var, file!(), line!());
-                    *value = Unknown;
+                    if environment.has_variable(var){
+                        let value = environment.get_mut_variable_or_break(var, file!(), line!());
+                        *value = Unknown;
+                    }
                 }   
             }
 


### PR DESCRIPTION
It appears https://github.com/iden3/circom/commit/0d775648c03516328c875d858e0c1b27cd1887c2 introduced some new static analysis that crashes on certain type of circuits that use mutable vars to index component arrays/constraints with this error:
```
thread 'main' panicked at 'Method call in file type_analysis/src/analyzers/unknown_known_analysis.rs line 216',
 /Users/nibnalin/Documents/circom/program_structure/src/utils/environment.rs:192:9
```
This patch fixes such issues. I don't quite understand the full details of the static analysis but I believe this check of modified variables should be similar to the check for `IfThenElse`, which correctly includes a `has_variable` check already, so that check is also required here.

An example circuit that reproduces the crash is in this gist when using circom 2.0.4 @ https://github.com/iden3/circom/commit/ad14e4a3d1dcc8ddb4f3eb633ebfdcef977bc239: https://gist.github.com/nalinbhardwaj/5d7ce7307ffca6033ddec68ff4b24388 . I've verified this patch fixes the crash.
