### PR TITLE
Undo removal of custom gates' signals in witness

### DIFF
--- a/dag/src/witness_producer.rs
+++ b/dag/src/witness_producer.rs
@@ -13,9 +13,7 @@ fn produce_tree_witness(tree: &Tree, witness: &mut Vec<usize>) {
         Vec::push(witness, *signal);
     }
     for edge in Tree::get_edges(tree) {
-        if !tree.dag.nodes[edge.get_goes_to()].is_custom_gate {
-            let subtree = Tree::go_to_subtree(tree, edge);
-            produce_tree_witness(&subtree, witness);
-        }
+        let subtree = Tree::go_to_subtree(tree, edge);
+        produce_tree_witness(&subtree, witness);
     }
 }


### PR DESCRIPTION
We must delay this removal until we know how to safely remove those same signals in the r1cs file