### PR TITLE
fix-summary-typo

### DIFF
--- a/mkdocs/docs/background/background.md
+++ b/mkdocs/docs/background/background.md
@@ -102,5 +102,5 @@ An assignment of the signals is called a **witness**. For example, `{a = 2, b = 
 
 ## Summary <a id="summary"></a>
 
-​**In summary, zk-SNARK proofs are an specific type of zero-knowledge proofs that allow you to prove that you know a set of signals \(witness\) that match all the constraints of a circuit without revealing any of the signals except the public inputs and the outputs.**
+​**In summary, zk-SNARK proofs are a specific type of zero-knowledge proofs that allow you to prove that you know a set of signals \(witness\) that match all the constraints of a circuit without revealing any of the signals except the public inputs and the outputs.**
 


### PR DESCRIPTION
The `Background in ZK` section contains a typo. So, I fixed it 
<img width="829" alt="Screenshot 2022-06-08 at 18 37 30" src="https://user-images.githubusercontent.com/23613565/172681959-ef1a2879-4e56-4c72-90c5-241ef60379d1.png">

## Previous 

In summary, zk-SNARK proofs are _**an**_ specific type of zero-knowledge...

## New 

In summary, zk-SNARK proofs are _**a**_ specific type of zero-knowledge