### PR TITLE
feat: Allow `log(label, value)` & print labels in C witness generator

### DIFF
--- a/code_producers/src/wasm_elements/bls12381/witness_calculator.js
+++ b/code_producers/src/wasm_elements/bls12381/witness_calculator.js
@@ -75,7 +75,13 @@ module.exports = async function builder(code, options) {
 	for (let j=0; j<shared_rw_memory_size; j++) {
 	    arr[shared_rw_memory_size-1-j] = instance.exports.readSharedRWMemory(j);
 	}
-	console.log(fromArray32(arr));
+    const label = getMessage();
+    if(label){
+        console.log(label + ':', fromArray32(arr));
+    }else{
+        console.log(fromArray32(arr));
+    }
+	
     }
 
 };

--- a/code_producers/src/wasm_elements/bn128/witness_calculator.js
+++ b/code_producers/src/wasm_elements/bn128/witness_calculator.js
@@ -75,7 +75,12 @@ module.exports = async function builder(code, options) {
 	for (let j=0; j<shared_rw_memory_size; j++) {
 	    arr[shared_rw_memory_size-1-j] = instance.exports.readSharedRWMemory(j);
 	}
-	console.log(fromArray32(arr));
+	const label = getMessage();
+    if(label){
+        console.log(label + ':', fromArray32(arr));
+    }else{
+        console.log(fromArray32(arr));
+    }
     }
 
 };

--- a/code_producers/src/wasm_elements/goldilocks/witness_calculator.js
+++ b/code_producers/src/wasm_elements/goldilocks/witness_calculator.js
@@ -75,7 +75,12 @@ module.exports = async function builder(code, options) {
 	for (let j=0; j<shared_rw_memory_size; j++) {
 	    arr[shared_rw_memory_size-1-j] = instance.exports.readSharedRWMemory(j);
 	}
-	console.log(fromArray32(arr));
+	const label = getMessage();
+    if(label){
+        console.log(label + ':', fromArray32(arr));
+    }else{
+        console.log(fromArray32(arr));
+    }
     }
 
 };

--- a/code_producers/src/wasm_elements/wasm_code_generator.rs
+++ b/code_producers/src/wasm_elements/wasm_code_generator.rs
@@ -1140,15 +1140,27 @@ pub fn get_message_char_generator(producer: &WASMProducer) -> Vec<WasmInstructio
     instructions.push(set_constant("0"));
     instructions.push(add_return());
     instructions.push(add_else());
+
     instructions.push(set_constant(&producer.get_message_buffer_start().to_string()));
     instructions.push(get_local("$c"));
     instructions.push(add32());
-    instructions.push(load32_8u(None));
+    instructions.push(load32_8u(None)); // load value at current position in buffer
+
+    instructions.push(add_if()); // if the value is nonzero, increment buffer counter position
     instructions.push(set_constant(&producer.get_message_buffer_counter_position().to_string()));
     instructions.push(get_local("$c"));
     instructions.push(set_constant("1"));
     instructions.push(add32());
     instructions.push(store32(None)); // new current position in buffer
+    instructions.push(add_end());
+
+    // we have to load the current value at the buffer position again because we consumed
+    // the value for the if statement
+    instructions.push(set_constant(&producer.get_message_buffer_start().to_string()));
+    instructions.push(get_local("$c"));
+    instructions.push(add32());
+    instructions.push(load32_8u(None)); // load value at current position in buffer
+
     instructions.push(add_return());
     instructions.push(add_end());
     instructions.push(set_constant("0"));

--- a/compiler/src/intermediate_representation/log_bucket.rs
+++ b/compiler/src/intermediate_representation/log_bucket.rs
@@ -59,6 +59,7 @@ impl WriteWasm for LogBucket {
             
             let mut trunc_label = label.clone();
             trunc_label.truncate(producer.get_size_of_message_in_bytes());
+            trunc_label.push('\0'); // terminate message with a null byte
 
             // write out the label one character at a time
             for (i, c) in trunc_label.chars().enumerate() {
@@ -66,11 +67,6 @@ impl WriteWasm for LogBucket {
                 instructions.push(set_constant(&(c as usize).to_string()));
                 instructions.push(store32(None));
             }
-
-            // terminate message with a null byte
-            instructions.push(set_constant(&(producer.get_message_buffer_start() + trunc_label.chars().count()).to_string()));
-            instructions.push(set_constant("0"));
-            instructions.push(store32(None));
 
             // initialize message buffer position to 0
             instructions.push(set_constant(&producer.get_message_buffer_counter_position().to_string()));

--- a/compiler/src/intermediate_representation/log_bucket.rs
+++ b/compiler/src/intermediate_representation/log_bucket.rs
@@ -9,6 +9,7 @@ pub struct LogBucket {
     pub message_id: usize,
     pub print: InstructionPointer,
     pub is_parallel: bool,
+    pub label: Option<String>,
 }
 
 impl IntoInstruction for LogBucket {
@@ -66,8 +67,12 @@ impl WriteC for LogBucket {
         let to_string_call = build_call("Fr_element2str".to_string(), vec![argument_result]);
         let temp_var = "temp".to_string();
         let into_temp = format!("char* temp = {}", to_string_call);
-        let print_c =
-            build_call("printf".to_string(), vec!["\"%s\\n\"".to_string(), temp_var.clone()]);
+        let print_c = if let Some(label) = &self.label {
+            let label_str = format!("\"{}\"", label.to_string());
+            build_call("printf".to_string(), vec!["\"%s: %s\\n\"".to_string(), label_str, temp_var.clone()])
+        } else {
+            build_call("printf".to_string(), vec!["\"%s\\n\"".to_string(), temp_var.clone()])
+        };
         let delete_temp = format!("delete [] {}", temp_var);
         let mut log_c = argument_code;
         log_c.push("{".to_string());

--- a/compiler/src/intermediate_representation/translate.rs
+++ b/compiler/src/intermediate_representation/translate.rs
@@ -581,14 +581,15 @@ fn translate_assert(stmt: Statement, state: &mut State, context: &Context) {
 
 fn translate_log(stmt: Statement, state: &mut State, context: &Context) {
     use Statement::LogCall;
-    if let LogCall { meta, arg, .. } = stmt {
+    if let LogCall { meta, arg, label, .. } = stmt {
         let line = context.files.get_line(meta.start, meta.get_file_id()).unwrap();
         let code = translate_expression(arg, state, context);
         let log = LogBucket {
             line,
             message_id: state.message_id,
             print: code,
-            is_parallel: state.is_parallel
+            is_parallel: state.is_parallel,
+            label: label,
         }.allocate();
         state.code.push(log);
     }

--- a/parser/src/lang.lalrpop
+++ b/parser/src/lang.lalrpop
@@ -314,7 +314,10 @@ ParseStatement2 : Statement = {
     => build_constraint_equality(Meta::new(s,e),lhe,rhe),
 
     <s:@L> "log" "(" <arg: ParseExpression> ")" ";" <e:@R>
-    => build_log_call(Meta::new(s,e),arg),
+    => build_log_call(Meta::new(s,e),arg,None),
+
+    <s:@L> "log" "(" <label: STRING> "," <arg: ParseExpression> ")" ";" <e:@R>
+    => build_log_call(Meta::new(s,e),arg,Some(label)),
 
     <s:@L> "assert" "(" <arg: ParseExpression> ")" ";" <e:@R>
     => build_assert(Meta::new(s,e),arg),

--- a/program_structure/src/abstract_syntax_tree/ast.rs
+++ b/program_structure/src/abstract_syntax_tree/ast.rs
@@ -203,6 +203,7 @@ pub enum Statement {
     LogCall {
         meta: Meta,
         arg: Expression,
+        label: Option<String>,
     },
     Block {
         meta: Meta,

--- a/program_structure/src/abstract_syntax_tree/statement_builders.rs
+++ b/program_structure/src/abstract_syntax_tree/statement_builders.rs
@@ -53,8 +53,8 @@ pub fn build_constraint_equality(meta: Meta, lhe: Expression, rhe: Expression) -
     ConstraintEquality { meta, lhe, rhe }
 }
 
-pub fn build_log_call(meta: Meta, arg: Expression) -> Statement {
-    LogCall { meta, arg }
+pub fn build_log_call(meta: Meta, arg: Expression, label: Option<String>) -> Statement {
+    LogCall { meta, arg, label }
 }
 
 pub fn build_assert(meta: Meta, arg: Expression) -> Statement {

--- a/program_structure/src/program_library/error_code.rs
+++ b/program_structure/src/program_library/error_code.rs
@@ -72,6 +72,7 @@ pub enum ReportCode {
     CustomGateConstraint,
     CustomGateSubComponent,
     CustomGatesPragmaError,
+    LabelTooLongError(usize),
 }
 impl fmt::Display for ReportCode {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -146,6 +147,7 @@ impl fmt::Display for ReportCode {
             CustomGateConstraint => "CG02",
             CustomGateSubComponent => "CG03",
             CustomGatesPragmaError => "CG04",
+            LabelTooLongError(..) => "L01",
         };
         f.write_str(string_format)
     }

--- a/type_analysis/src/analyzers/type_check.rs
+++ b/type_analysis/src/analyzers/type_check.rs
@@ -242,7 +242,31 @@ fn type_statement(
                 );
             }
         }
-        LogCall { arg, meta, .. } | Assert { arg, meta } => {
+        LogCall { arg, meta, label, .. } => {
+            let arg_response = type_expression(arg, program_archive, analysis_information);
+            let arg_type = if let Result::Ok(t) = arg_response {
+                t
+            } else {
+                return;
+            };
+            if let Some(label) = label {
+                if label.len() > 240 {
+                    add_report(
+                        ReportCode::LabelTooLongError(label.len()),
+                        meta,
+                        &mut analysis_information.reports,
+                    )
+                }
+            }
+            if arg_type.is_template() || arg_type.dim() > 0 {
+                add_report(
+                    ReportCode::MustBeSingleArithmetic,
+                    meta,
+                    &mut analysis_information.reports,
+                )
+            }
+        }
+        Assert { arg, meta } => {
             let arg_response = type_expression(arg, program_archive, analysis_information);
             let arg_type = if let Result::Ok(t) = arg_response {
                 t
@@ -760,6 +784,7 @@ fn add_report(error_code: ReportCode, meta: &Meta, reports: &mut ReportCollectio
         WrongNumberOfArguments(expected, got) => {
             format!("Expecting {} arguments, {} where obtained", expected, got)
         }
+        LabelTooLongError(len) => format!("Label too long. Label is {} characters but must be <240", len),
         _ => panic!("Unimplemented error code"),
     };
     report.add_primary(location, file_id, message);

--- a/type_analysis/src/analyzers/type_check.rs
+++ b/type_analysis/src/analyzers/type_check.rs
@@ -242,7 +242,7 @@ fn type_statement(
                 );
             }
         }
-        LogCall { arg, meta } | Assert { arg, meta } => {
+        LogCall { arg, meta, .. } | Assert { arg, meta } => {
             let arg_response = type_expression(arg, program_archive, analysis_information);
             let arg_type = if let Result::Ok(t) = arg_response {
                 t


### PR DESCRIPTION
Fixes https://github.com/iden3/circom/issues/82

This PR adds `log("foo", 1)` syntax to the circom language. The label is then printed when generating a witness with the C++ witness generator. It is very hard to add these labels to the wasm generator, so the label is discarded and only the value is printed when generating with the witness in wasm.

This feature is a huge quality-of-life improvement for large circuit authors, like @yi-sun and other @0xPARC members.