### PR TITLE
fix: Log messages from wasm with better formatting

### DIFF
--- a/code_producers/src/wasm_elements/common/witness_calculator.js
+++ b/code_producers/src/wasm_elements/common/witness_calculator.js
@@ -14,6 +14,7 @@ module.exports = async function builder(code, options) {
     let wc;
 
     let errStr = "";
+    let msgStr = "";
     
     const instance = await WebAssembly.instantiate(wasmModule, {
         runtime: {
@@ -41,7 +42,19 @@ module.exports = async function builder(code, options) {
                 // console.error(getMessage());
 	    },
 	    writeBufferMessage : function() {
-                process.stdout.write(getMessage());
+			const msg = getMessage();
+			// Any calls to `log()` will always end with a `\n`, so that's when we print and reset
+			if (msg === "\n") {
+				console.log(msgStr);
+				msgStr = "";
+			} else {
+				// If we've buffered other content, put a space in between the items
+				if (msgStr !== "") {
+					msgStr += " "
+				}
+				// Then append the message to the message we are creating
+				msgStr += msg;
+			}
 	    },
 	    showSharedRWMemory : function() {
 		printSharedRWMemory ();
@@ -82,9 +95,13 @@ module.exports = async function builder(code, options) {
 	    arr[shared_rw_memory_size-1-j] = instance.exports.readSharedRWMemory(j);
 	}
 
-	process.stdout.write(fromArray32(arr).toString());
-	//console.log(fromArray32(arr));
-    }
+	// If we've buffered other content, put a space in between the items
+	if (msgStr !== "") {
+		msgStr += " "
+	}
+	// Then append the value to the message we are creating
+	msgStr += (fromArray32(arr).toString());
+	}
 
 };
 

--- a/compiler/src/intermediate_representation/log_bucket.rs
+++ b/compiler/src/intermediate_representation/log_bucket.rs
@@ -98,6 +98,7 @@ impl WriteC for LogBucket {
     fn produce_c(&self, producer: &CProducer) -> (Vec<String>, String) {
         use c_code_generator::*;
         let mut log_c = Vec::new();
+        let mut index = 0;
         for logarg in &self.argsprint {
             if let LogBucketArg::LogExp(exp) = logarg {
                 let (mut argument_code, argument_result) = exp.produce_c(producer);
@@ -129,14 +130,25 @@ impl WriteC for LogBucket {
             else{
                 unreachable!();
             }
+            if index != self.argsprint.len() - 1 { 
+                let print_c =
+                    build_call(
+                        "printf".to_string(), 
+                        vec![format!("\" \"")]
+                    );
+                log_c.push("{".to_string());
+                log_c.push(format!("{};", print_c));
+                log_c.push("}".to_string());
+            }
+            index += 1;
         }
         let print_end_line = build_call(
             "printf".to_string(), 
             vec![format!("\"\\n\"")]
         );
         log_c.push("{".to_string());
-                log_c.push(format!("{};", print_end_line));
-                log_c.push("}".to_string());
+        log_c.push(format!("{};", print_end_line));
+        log_c.push("}".to_string());
         (log_c, "".to_string())
     }
 }

--- a/constraint_generation/src/execute.rs
+++ b/constraint_generation/src/execute.rs
@@ -300,6 +300,7 @@ fn execute_statement(
         }
         LogCall { args, .. } => {
             if flag_verbose{
+                let mut index = 0;
                 for arglog in args {
                     if let LogArgument::LogExp(arg) = arglog{
                         let f_result = execute_expression(arg, program_archive, runtime, flag_verbose)?;
@@ -314,6 +315,10 @@ fn execute_statement(
                     else if let LogArgument::LogStr(s) = arglog {
                             print!("{}",s);
                     }
+                    if index != args.len()-1{
+                        print!(" ");
+                    }
+                    index += 1;
                 }
                 println!("");
             }


### PR DESCRIPTION
This fixes the `log()` printing for wasm. Previously, `log("foo", 1, "bar", 2)` would print as `foo1bar2` but with this change it will log as `foo 1 bar 2`

This also removes the need for `process.stdout` which isn't portable to the browser. I encountered this issue when migrating the log changes to circom_runtime for snarkjs.