### PR TITLE
feat: Add `getMinorVersion` and `getPatchVersion` exports to wasm output

### DIFF
--- a/circom/src/compilation_user.rs
+++ b/circom/src/compilation_user.rs
@@ -4,6 +4,8 @@ use compiler::compiler_interface::{Config, VCP};
 use program_structure::error_definition::Report;
 use program_structure::error_code::ReportCode;
 use program_structure::file_definition::FileLibrary;
+use crate::VERSION;
+
 
 pub struct CompilerConfig {
     pub js_folder: String,
@@ -26,6 +28,7 @@ pub fn compile(config: CompilerConfig) -> Result<(), ()> {
     let circuit = compiler_interface::run_compiler(
         config.vcp,
         Config { debug_output: config.debug_output, produce_input_log: config.produce_input_log, wat_flag: config.wat_flag },
+        VERSION
     )?;
 
     if config.c_flag {

--- a/circom_algebra/Cargo.toml
+++ b/circom_algebra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circom_algebra"
-version = "2.0.4"
+version = "2.0.7"
 authors = ["Costa Group UCM","iden3"]
 edition = "2018"
 

--- a/code_producers/Cargo.toml
+++ b/code_producers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code_producers"
-version = "2.0.4"
+version = "2.0.7"
 authors = ["Costa Group UCM","iden3"]
 edition = "2018"
 

--- a/code_producers/src/c_elements/mod.rs
+++ b/code_producers/src/c_elements/mod.rs
@@ -103,9 +103,6 @@ impl CProducer {
     pub fn get_version(&self) -> usize {
         self.major_version
     }
-    pub fn get_major_version(&self) -> usize {
-        self.major_version
-    }
     pub fn get_minor_version(&self) -> usize {
         self.minor_version
     }

--- a/code_producers/src/c_elements/mod.rs
+++ b/code_producers/src/c_elements/mod.rs
@@ -1,6 +1,6 @@
 pub mod c_code_generator;
 
-pub use crate::{components::*, get_number_version};
+pub use crate::components::*;
 
 pub type CInstruction = String;
 pub struct CProducer {
@@ -24,9 +24,9 @@ pub struct CProducer {
     pub template_instance_list: TemplateList,
     pub message_list: MessageList,
     pub field_tracking: Vec<String>,
-    major_version: usize,
-    minor_version: usize,
-    patch_version: usize,
+    pub major_version: usize,
+    pub minor_version: usize,
+    pub patch_version: usize,
     name_tag: String,
     string_table: Vec<String>,
 }
@@ -57,7 +57,6 @@ impl Default for CProducer {
                 IODef { code: 2, offset: 5, lengths: [2, 6].to_vec() },
             ],
         );
-        let (major_version, minor_version, patch_version) = get_number_version();
         CProducer {
             main_header: "Main_0".to_string(),
             has_parallelism: false,
@@ -90,9 +89,9 @@ impl Default for CProducer {
             size_32_shift: 5,
             io_map: my_map, //TemplateInstanceIOMap::new(),
             template_instance_list: [].to_vec(),
-            major_version,
-            minor_version,
-            patch_version,
+            major_version: 0,
+            minor_version: 0,
+            patch_version: 0,
             name_tag: "name".to_string(),
             string_table: Vec::new(),
         }

--- a/code_producers/src/c_elements/mod.rs
+++ b/code_producers/src/c_elements/mod.rs
@@ -1,6 +1,6 @@
 pub mod c_code_generator;
 
-pub use crate::components::*;
+pub use crate::{components::*, get_number_version};
 
 pub type CInstruction = String;
 pub struct CProducer {
@@ -24,7 +24,9 @@ pub struct CProducer {
     pub template_instance_list: TemplateList,
     pub message_list: MessageList,
     pub field_tracking: Vec<String>,
-    version: usize,
+    major_version: usize,
+    minor_version: usize,
+    patch_version: usize,
     name_tag: String,
     string_table: Vec<String>,
 }
@@ -55,6 +57,7 @@ impl Default for CProducer {
                 IODef { code: 2, offset: 5, lengths: [2, 6].to_vec() },
             ],
         );
+        let (major_version, minor_version, patch_version) = get_number_version();
         CProducer {
             main_header: "Main_0".to_string(),
             has_parallelism: false,
@@ -87,17 +90,27 @@ impl Default for CProducer {
             size_32_shift: 5,
             io_map: my_map, //TemplateInstanceIOMap::new(),
             template_instance_list: [].to_vec(),
-            // fix values
-            version: 2,
+            major_version,
+            minor_version,
+            patch_version,
             name_tag: "name".to_string(),
-            string_table : Vec::new(),
+            string_table: Vec::new(),
         }
     }
 }
 
 impl CProducer {
     pub fn get_version(&self) -> usize {
-        self.version
+        self.major_version
+    }
+    pub fn get_major_version(&self) -> usize {
+        self.major_version
+    }
+    pub fn get_minor_version(&self) -> usize {
+        self.minor_version
+    }
+    pub fn get_patch_version(&self) -> usize {
+        self.patch_version
     }
     pub fn get_main_header(&self) -> &str {
         &self.main_header

--- a/code_producers/src/lib.rs
+++ b/code_producers/src/lib.rs
@@ -4,3 +4,16 @@ pub mod c_elements;
 pub mod wasm_elements;
 
 pub mod components;
+
+use std::str::FromStr;
+
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+pub fn get_number_version() -> (usize, usize, usize) {
+    let version_splitted: Vec<&str> = VERSION.split(".").collect();
+    (
+        usize::from_str(version_splitted[0]).unwrap(),
+        usize::from_str(version_splitted[1]).unwrap(),
+        usize::from_str(version_splitted[2]).unwrap(),
+    )
+}

--- a/code_producers/src/lib.rs
+++ b/code_producers/src/lib.rs
@@ -4,16 +4,3 @@ pub mod c_elements;
 pub mod wasm_elements;
 
 pub mod components;
-
-use std::str::FromStr;
-
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
-
-pub fn get_number_version() -> (usize, usize, usize) {
-    let version_splitted: Vec<&str> = VERSION.split(".").collect();
-    (
-        usize::from_str(version_splitted[0]).unwrap(),
-        usize::from_str(version_splitted[1]).unwrap(),
-        usize::from_str(version_splitted[2]).unwrap(),
-    )
-}

--- a/code_producers/src/wasm_elements/mod.rs
+++ b/code_producers/src/wasm_elements/mod.rs
@@ -1,6 +1,6 @@
 pub mod wasm_code_generator;
 
-use crate::{components::*, get_number_version};
+use crate::components::*;
 
 type WasmInstruction = String;
 
@@ -25,9 +25,9 @@ pub struct WASMProducer {
     pub message_list: MessageList,
     pub field_tracking: Vec<String>,
     pub wat_flag: bool,
-    major_version: usize,
-    minor_version: usize,
-    patch_version: usize,
+    pub major_version: usize,
+    pub minor_version: usize,
+    pub patch_version: usize,
     stack_free_pos: usize,
     local_info_size_u32: usize,
     size_of_message_buffer_in_bytes: usize,
@@ -61,7 +61,6 @@ impl Default for WASMProducer {
         //my_map.insert(0,[(0,0),(1,2),(2,4)].to_vec());
         //my_map.insert(1,[(0,0),(1,1)].to_vec());
         //my_map.insert(2,[(0,0),(1,1),(2,3)].to_vec());
-        let (major_version, minor_version, patch_version) = get_number_version();
         WASMProducer {
             main_header: "Main_0".to_string(),
             main_signal_offset: 1,
@@ -84,9 +83,9 @@ impl Default for WASMProducer {
             template_instance_list: [].to_vec(),
             field_tracking: [].to_vec(),
             wat_flag: true,
-            major_version,
-            minor_version,
-            patch_version,
+            major_version: 0,
+            minor_version: 0,
+            patch_version: 0,
             stack_free_pos: 0,
             local_info_size_u32: 0, // in the future we can add some info like pointer to run father or text father
             size_of_message_buffer_in_bytes: 256,

--- a/code_producers/src/wasm_elements/mod.rs
+++ b/code_producers/src/wasm_elements/mod.rs
@@ -148,9 +148,6 @@ impl WASMProducer {
     pub fn get_version(&self) -> usize {
         self.major_version
     }
-    pub fn get_major_version(&self) -> usize {
-        self.major_version
-    }
     pub fn get_minor_version(&self) -> usize {
         self.minor_version
     }

--- a/code_producers/src/wasm_elements/mod.rs
+++ b/code_producers/src/wasm_elements/mod.rs
@@ -1,6 +1,6 @@
 pub mod wasm_code_generator;
 
-use crate::components::*;
+use crate::{components::*, get_number_version};
 
 type WasmInstruction = String;
 
@@ -25,7 +25,9 @@ pub struct WASMProducer {
     pub message_list: MessageList,
     pub field_tracking: Vec<String>,
     pub wat_flag: bool,
-    version: usize,
+    major_version: usize,
+    minor_version: usize,
+    patch_version: usize,
     stack_free_pos: usize,
     local_info_size_u32: usize,
     size_of_message_buffer_in_bytes: usize,
@@ -59,6 +61,7 @@ impl Default for WASMProducer {
         //my_map.insert(0,[(0,0),(1,2),(2,4)].to_vec());
         //my_map.insert(1,[(0,0),(1,1)].to_vec());
         //my_map.insert(2,[(0,0),(1,1),(2,3)].to_vec());
+        let (major_version, minor_version, patch_version) = get_number_version();
         WASMProducer {
             main_header: "Main_0".to_string(),
             main_signal_offset: 1,
@@ -81,8 +84,9 @@ impl Default for WASMProducer {
             template_instance_list: [].to_vec(),
             field_tracking: [].to_vec(),
             wat_flag: true,
-            // fix values
-            version: 2,
+            major_version,
+            minor_version,
+            patch_version,
             stack_free_pos: 0,
             local_info_size_u32: 0, // in the future we can add some info like pointer to run father or text father
             size_of_message_buffer_in_bytes: 256,
@@ -142,7 +146,16 @@ impl WASMProducer {
         }
     */
     pub fn get_version(&self) -> usize {
-        self.version
+        self.major_version
+    }
+    pub fn get_major_version(&self) -> usize {
+        self.major_version
+    }
+    pub fn get_minor_version(&self) -> usize {
+        self.minor_version
+    }
+    pub fn get_patch_version(&self) -> usize {
+        self.patch_version
     }
     pub fn get_main_header(&self) -> &str {
         &self.main_header

--- a/code_producers/src/wasm_elements/wasm_code_generator.rs
+++ b/code_producers/src/wasm_elements/wasm_code_generator.rs
@@ -532,7 +532,6 @@ pub fn generate_exports_list() -> Vec<WasmInstruction> {
     let mut exports = vec![];
     exports.push("(export \"memory\" (memory 0))".to_string());
     exports.push("(export \"getVersion\" (func $getVersion))".to_string());
-    exports.push("(export \"getMajorVersion\" (func $getMajorVersion))".to_string());
     exports.push("(export \"getMinorVersion\" (func $getMinorVersion))".to_string());
     exports.push("(export \"getPatchVersion\" (func $getPatchVersion))".to_string());
     exports.push("(export \"getSharedRWMemoryStart\" (func $getSharedRWMemoryStart))".to_string());
@@ -776,10 +775,6 @@ pub fn get_version_generator(producer: &WASMProducer) -> Vec<WasmInstruction> {
     let header = "(func $getVersion (type $_t_ri32)".to_string();
     instructions.push(header);
     instructions.push(set_constant(&producer.get_version().to_string()));
-    instructions.push(")".to_string());
-    let header = "(func $getMajorVersion (type $_t_ri32)".to_string();
-    instructions.push(header);
-    instructions.push(set_constant(&producer.get_major_version().to_string()));
     instructions.push(")".to_string());
     let header = "(func $getMinorVersion (type $_t_ri32)".to_string();
     instructions.push(header);

--- a/code_producers/src/wasm_elements/wasm_code_generator.rs
+++ b/code_producers/src/wasm_elements/wasm_code_generator.rs
@@ -532,6 +532,9 @@ pub fn generate_exports_list() -> Vec<WasmInstruction> {
     let mut exports = vec![];
     exports.push("(export \"memory\" (memory 0))".to_string());
     exports.push("(export \"getVersion\" (func $getVersion))".to_string());
+    exports.push("(export \"getMajorVersion\" (func $getMajorVersion))".to_string());
+    exports.push("(export \"getMinorVersion\" (func $getMinorVersion))".to_string());
+    exports.push("(export \"getPatchVersion\" (func $getPatchVersion))".to_string());
     exports.push("(export \"getSharedRWMemoryStart\" (func $getSharedRWMemoryStart))".to_string());
     exports.push("(export \"readSharedRWMemory\" (func $readSharedRWMemory))".to_string());
     exports.push("(export \"writeSharedRWMemory\" (func $writeSharedRWMemory))".to_string());
@@ -773,6 +776,18 @@ pub fn get_version_generator(producer: &WASMProducer) -> Vec<WasmInstruction> {
     let header = "(func $getVersion (type $_t_ri32)".to_string();
     instructions.push(header);
     instructions.push(set_constant(&producer.get_version().to_string()));
+    instructions.push(")".to_string());
+    let header = "(func $getMajorVersion (type $_t_ri32)".to_string();
+    instructions.push(header);
+    instructions.push(set_constant(&producer.get_major_version().to_string()));
+    instructions.push(")".to_string());
+    let header = "(func $getMinorVersion (type $_t_ri32)".to_string();
+    instructions.push(header);
+    instructions.push(set_constant(&producer.get_minor_version().to_string()));
+    instructions.push(")".to_string());
+    let header = "(func $getPatchVersion (type $_t_ri32)".to_string();
+    instructions.push(header);
+    instructions.push(set_constant(&producer.get_patch_version().to_string()));
     instructions.push(")".to_string());
     instructions
 }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler"
-version = "2.0.4"
+version = "2.0.7"
 authors = ["Costa Group UCM","iden3"]
 edition = "2018"
 

--- a/compiler/src/circuit_design/circuit.rs
+++ b/compiler/src/circuit_design/circuit.rs
@@ -392,9 +392,9 @@ impl WriteC for Circuit {
 }
 
 impl Circuit {
-    pub fn build(vcp: VCP, flags: CompilationFlags) -> Self {
+    pub fn build(vcp: VCP, flags: CompilationFlags, version: &str) -> Self {
         use super::build::build_circuit;
-        build_circuit(vcp, flags)
+        build_circuit(vcp, flags, version)
     }
     pub fn add_template_code(&mut self, template_info: TemplateCodeInfo) -> ID {
         let id = self.templates.len();

--- a/compiler/src/compiler_interface.rs
+++ b/compiler/src/compiler_interface.rs
@@ -9,9 +9,9 @@ pub struct Config {
     pub wat_flag: bool,
 }
 
-pub fn run_compiler(vcp: VCP, config: Config) -> Result<Circuit, ()> {
+pub fn run_compiler(vcp: VCP, config: Config, version: &str) -> Result<Circuit, ()> {
     let flags = CompilationFlags { main_inputs_log: config.produce_input_log, wat_flag: config.wat_flag };
-    let circuit = Circuit::build(vcp, flags);
+    let circuit = Circuit::build(vcp, flags, version);
     if config.debug_output {
         produce_debug_output(&circuit)?;
     }

--- a/constraint_generation/Cargo.toml
+++ b/constraint_generation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constraint_generation"
-version = "2.0.4"
+version = "2.0.7"
 authors = ["Costa Group UCM","iden3"]
 edition = "2018"
 

--- a/constraint_list/Cargo.toml
+++ b/constraint_list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constraint_list"
-version = "2.0.4"
+version = "2.0.7"
 authors = ["Costa Group UCM","iden3"]
 edition = "2018"
 

--- a/constraint_writers/Cargo.toml
+++ b/constraint_writers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constraint_writers"
-version = "2.0.4"
+version = "2.0.7"
 authors = ["Costa Group UCM","iden3"]
 edition = "2018"
 

--- a/constraint_writers/Cargo.toml
+++ b/constraint_writers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constraint_writers"
-version = "2.0.7"
+version = "2.0.6"
 authors = ["Costa Group UCM","iden3"]
 edition = "2018"
 

--- a/dag/Cargo.toml
+++ b/dag/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dag"
-version = "2.0.4"
+version = "2.0.7"
 authors = ["Costa Group UCM","iden3"]
 edition = "2018"
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parser"
-version = "2.0.4"
+version = "2.0.7"
 authors = ["Costa Group UCM","iden3"]
 edition = "2018"
 build = "build.rs"

--- a/program_structure/Cargo.toml
+++ b/program_structure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "program_structure"
-version = "2.0.4"
+version = "2.0.7"
 authors = ["Costa Group UCM","iden3"]
 edition = "2018"
 

--- a/type_analysis/Cargo.toml
+++ b/type_analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type_analysis"
-version = "2.0.4"
+version = "2.0.7"
 authors = ["Costa Group UCM","iden3"]
 edition = "2018"
 


### PR DESCRIPTION
Since SnarkJS needs to support all versions of circom, and this project doesn't follow semantic versioning, it would be helpful to include all digits in the version number returned by the `getVersion` export.

This would allow us to do feature switching based on the version of the compiler.