### PR TITLE
Only printing sections 4 and 5 of the R1CS file when necessary

### DIFF
--- a/circom/src/execution_user.rs
+++ b/circom/src/execution_user.rs
@@ -40,6 +40,7 @@ pub fn execute_project(
         flag_old_heuristics: config.flag_old_heuristics,
         prime : config.prime,
     };
+    let custom_gates = program_archive.custom_gates;
     let (exporter, vcp) = build_circuit(program_archive, build_config)?;
     if config.r1cs_flag {
         generate_output_r1cs(&config.r1cs, exporter.as_ref(), custom_gates)?;

--- a/circom/src/execution_user.rs
+++ b/circom/src/execution_user.rs
@@ -42,7 +42,7 @@ pub fn execute_project(
     };
     let (exporter, vcp) = build_circuit(program_archive, build_config)?;
     if config.r1cs_flag {
-        generate_output_r1cs(&config.r1cs, exporter.as_ref())?;
+        generate_output_r1cs(&config.r1cs, exporter.as_ref(), custom_gates)?;
     }
     if config.sym_flag {
         generate_output_sym(&config.sym, exporter.as_ref())?;
@@ -53,8 +53,8 @@ pub fn execute_project(
     Result::Ok(vcp)
 }
 
-fn generate_output_r1cs(file: &str, exporter: &dyn ConstraintExporter) -> Result<(), ()> {
-    if let Result::Ok(()) = exporter.r1cs(file) {
+fn generate_output_r1cs(file: &str, exporter: &dyn ConstraintExporter, custom_gates: bool) -> Result<(), ()> {
+    if let Result::Ok(()) = exporter.r1cs(file, custom_gates) {
         println!("{} {}", Colour::Green.paint("Written successfully:"), file);
         Result::Ok(())
     } else {

--- a/constraint_list/src/lib.rs
+++ b/constraint_list/src/lib.rs
@@ -163,8 +163,8 @@ pub struct ConstraintList {
 }
 
 impl ConstraintExporter for ConstraintList {
-    fn r1cs(&self, out: &str) -> Result<(), ()> {
-        r1cs_porting::port_r1cs(self, out)
+    fn r1cs(&self, out: &str, custom_gates: bool) -> Result<(), ()> {
+        r1cs_porting::port_r1cs(self, out, custom_gates)
     }
 
     fn json_constraints(&self, writer: &DebugWriter) -> Result<(), ()> {

--- a/constraint_list/src/r1cs_porting.rs
+++ b/constraint_list/src/r1cs_porting.rs
@@ -1,7 +1,7 @@
 use super::{ConstraintList, C, EncodingIterator, SignalMap};
 use constraint_writers::r1cs_writer::{ConstraintSection, CustomGatesAppliedData, HeaderData, R1CSWriter, SignalSection};
 
-pub fn port_r1cs(list: &ConstraintList, output: &str) -> Result<(), ()> {
+pub fn port_r1cs(list: &ConstraintList, output: &str, custom_gates: bool) -> Result<(), ()> {
     use constraint_writers::log_writer::Log;
     let field_size = (list.field.bits() / 64 + 1) * 8;
     let mut log = Log::new();
@@ -47,69 +47,71 @@ pub fn port_r1cs(list: &ConstraintList, output: &str) -> Result<(), ()> {
     }
     let r1cs = signal_section.end_section()?;
 
-    let mut custom_gates_used_section = R1CSWriter::start_custom_gates_used_section(r1cs)?;
-    let (usage_data, occurring_order) = {
-        let mut usage_data = vec![];
-        let mut occurring_order = vec![];
-        for node in &list.dag_encoding.nodes {
-            if node.is_custom_gate {
-                let mut name = node.name.clone();
-                occurring_order.push(name.clone());
-                while name.pop() != Some('(') {};
-                usage_data.push((name, node.parameters.clone()));
-            }
-        }
-        (usage_data, occurring_order)
-    };
-    custom_gates_used_section.write_custom_gates_usages(usage_data)?;
-    let r1cs = custom_gates_used_section.end_section()?;
-
-    let mut custom_gates_applied_section = R1CSWriter::start_custom_gates_applied_section(r1cs)?;
-    let application_data = {
-        fn find_indexes(
-            occurring_order: Vec<String>,
-            application_data: Vec<(String, Vec<usize>)>
-        ) -> CustomGatesAppliedData {
-            let mut new_application_data = vec![];
-            for (custom_gate_name, signals) in application_data {
-                let mut index = 0;
-                while occurring_order[index] != custom_gate_name {
-                    index += 1;
-                }
-                new_application_data.push((index, signals));
-            }
-            new_application_data
-        }
-
-        fn iterate(
-            iterator: EncodingIterator,
-            map: &SignalMap,
-            application_data: &mut Vec<(String, Vec<usize>)>
-        ) {
-            let node = &iterator.encoding.nodes[iterator.node_id];
-            if node.is_custom_gate {
-                let mut signals = vec![];
-                for signal in &node.ordered_signals {
-                    let new_signal = signal + iterator.offset;
-                    let signal_numbering = map.get(&new_signal).unwrap();
-                    signals.push(*signal_numbering);
-                }
-                application_data.push((node.name.clone(), signals));
-            } else {
-                for edge in EncodingIterator::edges(&iterator) {
-                    let next = EncodingIterator::next(&iterator, edge);
-                    iterate(next, map, application_data);
+    if custom_gates {
+        let mut custom_gates_used_section = R1CSWriter::start_custom_gates_used_section(r1cs)?;
+        let (usage_data, occurring_order) = {
+            let mut usage_data = vec![];
+            let mut occurring_order = vec![];
+            for node in &list.dag_encoding.nodes {
+                if node.is_custom_gate {
+                    let mut name = node.name.clone();
+                    occurring_order.push(name.clone());
+                    while name.pop() != Some('(') {};
+                    usage_data.push((name, node.parameters.clone()));
                 }
             }
-        }
+            (usage_data, occurring_order)
+        };
+        custom_gates_used_section.write_custom_gates_usages(usage_data)?;
+        let r1cs = custom_gates_used_section.end_section()?;
 
-        let mut application_data = vec![];
-        let iterator = EncodingIterator::new(&list.dag_encoding);
-        iterate(iterator, &list.signal_map, &mut application_data);
-        find_indexes(occurring_order, application_data)
-    };
-    custom_gates_applied_section.write_custom_gates_applications(application_data)?;
-    let _r1cs = custom_gates_applied_section.end_section()?;
+        let mut custom_gates_applied_section = R1CSWriter::start_custom_gates_applied_section(r1cs)?;
+        let application_data = {
+            fn find_indexes(
+                occurring_order: Vec<String>,
+                application_data: Vec<(String, Vec<usize>)>
+            ) -> CustomGatesAppliedData {
+                let mut new_application_data = vec![];
+                for (custom_gate_name, signals) in application_data {
+                    let mut index = 0;
+                    while occurring_order[index] != custom_gate_name {
+                        index += 1;
+                    }
+                    new_application_data.push((index, signals));
+                }
+                new_application_data
+            }
+
+            fn iterate(
+                iterator: EncodingIterator,
+                map: &SignalMap,
+                application_data: &mut Vec<(String, Vec<usize>)>
+            ) {
+                let node = &iterator.encoding.nodes[iterator.node_id];
+                if node.is_custom_gate {
+                    let mut signals = vec![];
+                    for signal in &node.ordered_signals {
+                        let new_signal = signal + iterator.offset;
+                        let signal_numbering = map.get(&new_signal).unwrap();
+                        signals.push(*signal_numbering);
+                    }
+                    application_data.push((node.name.clone(), signals));
+                } else {
+                    for edge in EncodingIterator::edges(&iterator) {
+                        let next = EncodingIterator::next(&iterator, edge);
+                        iterate(next, map, application_data);
+                    }
+                }
+            }
+
+            let mut application_data = vec![];
+            let iterator = EncodingIterator::new(&list.dag_encoding);
+            iterate(iterator, &list.signal_map, &mut application_data);
+            find_indexes(occurring_order, application_data)
+        };
+        custom_gates_applied_section.write_custom_gates_applications(application_data)?;
+        let _r1cs = custom_gates_applied_section.end_section()?;
+    }
 
     Log::print(&log);
     Ok(())

--- a/constraint_writers/src/lib.rs
+++ b/constraint_writers/src/lib.rs
@@ -5,7 +5,7 @@ pub mod r1cs_writer;
 pub mod sym_writer;
 
 pub trait ConstraintExporter {
-    fn r1cs(&self, out: &str) -> Result<(), ()>;
+    fn r1cs(&self, out: &str, custom_gates: bool) -> Result<(), ()>;
     fn json_constraints(&self, writer: &debug_writer::DebugWriter) -> Result<(), ()>;
     fn sym(&self, out: &str) -> Result<(), ()>;
 }

--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -287,8 +287,8 @@ pub struct DAG {
 }
 
 impl ConstraintExporter for DAG {
-    fn r1cs(&self, out: &str) -> Result<(), ()> {
-        DAG::generate_r1cs_output(self, out)
+    fn r1cs(&self, out: &str, custom_gates: bool) -> Result<(), ()> {
+        DAG::generate_r1cs_output(self, out, custom_gates)
     }
 
     fn json_constraints(&self, writer: &DebugWriter) -> Result<(), ()> {
@@ -442,8 +442,8 @@ impl DAG {
         }
     }
 
-    pub fn generate_r1cs_output(&self, output_file: &str) -> Result<(), ()> {
-        r1cs_porting::write(self, output_file)
+    pub fn generate_r1cs_output(&self, output_file: &str, custom_gates: bool) -> Result<(), ()> {
+        r1cs_porting::write(self, output_file, custom_gates)
     }
 
     pub fn generate_sym_output(&self, output_file: &str) -> Result<(), ()> {

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -70,7 +70,7 @@ pub fn run_parser(
         let program = parser_logic::parse_file(&src, file_id)
             .map_err(|e| (file_library.clone(), vec![e]))?;
         if let Some(main) = program.main_component {
-            main_components.push((file_id, main));
+            main_components.push((file_id, main, program.custom_gates));
         }
         includes_graph.add_node(crr_str_file, program.custom_gates, program.custom_gates_declared);
         let includes = program.includes;
@@ -116,9 +116,9 @@ pub fn run_parser(
         if errors.len() > 0 {
             Err((file_library, errors))
         } else {
-            let (main_id, main_component) = main_components.pop().unwrap();
+            let (main_id, main_component, custom_gates) = main_components.pop().unwrap();
             let result_program_archive =
-                ProgramArchive::new(file_library, main_id, main_component, definitions);
+                ProgramArchive::new(file_library, main_id, main_component, definitions, custom_gates);
             match result_program_archive {
                 Err((lib, rep)) => {
                     Err((lib, rep))

--- a/program_structure/src/program_library/program_archive.rs
+++ b/program_structure/src/program_library/program_archive.rs
@@ -20,6 +20,7 @@ pub struct ProgramArchive {
     pub template_keys: HashSet<String>,
     pub public_inputs: Vec<String>,
     pub initial_template_call: Expression,
+    pub custom_gates: bool,
 }
 impl ProgramArchive {
     pub fn new(
@@ -27,6 +28,7 @@ impl ProgramArchive {
         file_id_main: FileID,
         main_component: MainComponent,
         program_contents: Contents,
+        custom_gates: bool,
     ) -> Result<ProgramArchive, (FileLibrary, Vec<Report>)> {
         let mut merger = Merger::new();
         let mut reports = vec![];
@@ -57,6 +59,7 @@ impl ProgramArchive {
                 initial_template_call,
                 function_keys,
                 template_keys,
+                custom_gates,
             })
         } else {
             Err((file_library, reports))


### PR DESCRIPTION
When the files are being parsed, it's checked if the file containing the main component (there should be just one of those files in a correct circuit definition) is using the custom templates pragma. That information is used later, when writing the R1CS file, to avoid writing sections 4 and 5 if custom templates are not being used.