### PR TITLE
fix c++ witness code producer on macos with clang 14.0.0

### DIFF
--- a/code_producers/src/c_elements/bls12381/fr.hpp
+++ b/code_producers/src/c_elements/bls12381/fr.hpp
@@ -5,6 +5,10 @@
 #include <string>
 #include <gmp.h>
 
+#ifdef __APPLE__
+#include <sys/types.h> // typedef unsigned int uint;
+#endif // __APPLE__
+
 #define Fr_N64 4
 #define Fr_SHORT 0x00000000
 #define Fr_LONG 0x80000000
@@ -126,7 +130,7 @@ public:
     Element inline add(const Element &a, int b) { return add(a, set(b));};
     Element inline sub(const Element &a, int b) { return sub(a, set(b));};
     Element inline mul(const Element &a, int b) { return mul(a, set(b));};
-    
+
     void inline mul1(Element &r, const Element &a, uint64_t b) { Fr_rawMMul1(r.v, a.v, b); };
     void inline neg(Element &r, const Element &a) { Fr_rawNeg(r.v, a.v); };
     void inline square(Element &r, const Element &a) { Fr_rawMSquare(r.v, a.v); };
@@ -144,9 +148,9 @@ public:
 
     int toRprBE(const Element &element, uint8_t *data, int bytes);
     int fromRprBE(Element &element, const uint8_t *data, int bytes);
-    
+
     int bytes ( void ) { return Fr_N64 * 8; };
-    
+
     void fromUI(Element &r, unsigned long int v);
 
     static RawFr field;

--- a/code_producers/src/c_elements/bn128/fr.hpp
+++ b/code_producers/src/c_elements/bn128/fr.hpp
@@ -5,6 +5,10 @@
 #include <string>
 #include <gmp.h>
 
+#ifdef __APPLE__
+#include <sys/types.h> // typedef unsigned int uint;
+#endif // __APPLE__
+
 #define Fr_N64 4
 #define Fr_SHORT 0x00000000
 #define Fr_LONG 0x80000000
@@ -126,7 +130,7 @@ public:
     Element inline add(const Element &a, int b) { return add(a, set(b));};
     Element inline sub(const Element &a, int b) { return sub(a, set(b));};
     Element inline mul(const Element &a, int b) { return mul(a, set(b));};
-    
+
     void inline mul1(Element &r, const Element &a, uint64_t b) { Fr_rawMMul1(r.v, a.v, b); };
     void inline neg(Element &r, const Element &a) { Fr_rawNeg(r.v, a.v); };
     void inline square(Element &r, const Element &a) { Fr_rawMSquare(r.v, a.v); };
@@ -144,9 +148,9 @@ public:
 
     int toRprBE(const Element &element, uint8_t *data, int bytes);
     int fromRprBE(Element &element, const uint8_t *data, int bytes);
-    
+
     int bytes ( void ) { return Fr_N64 * 8; };
-    
+
     void fromUI(Element &r, unsigned long int v);
 
     static RawFr field;


### PR DESCRIPTION
There was error while doing `make` command in generated cpp directory. Error example:
```
g++ -c fr.cpp -std=c++11 -O3 -I.
In file included from fr.cpp:1:
./fr.hpp:71:50: error: unknown type name 'uint'; did you mean 'int'?
void Fr_str2element(PFrElement pE, char const*s, uint base);
                                                 ^~~~
                                                 int
fr.cpp:56:51: error: unknown type name 'uint'; did you mean 'int'?
void Fr_str2element(PFrElement pE, char const *s, uint base) {
                                                  ^~~~
                                                  int
```