### PR TITLE
Fix unit tests

### DIFF
--- a/code_producers/src/c_elements/c_code_generator.rs
+++ b/code_producers/src/c_elements/c_code_generator.rs
@@ -165,15 +165,11 @@ pub fn declare_my_template_name() -> CInstruction {
     )
 }
 pub fn declare_my_template_name_function(name: &String) -> CInstruction {
-    format!(
-        "std::string {} = \"{}\"",
-        MY_TEMPLATE_NAME, name.to_string()
-    )
+    format!("std::string {} = \"{}\"", MY_TEMPLATE_NAME, name.to_string())
 }
 pub fn my_template_name() -> CInstruction {
     format!("{}", MY_TEMPLATE_NAME)
 }
-
 
 pub const MY_COMPONENT_NAME: &str = "myComponentName";
 pub fn declare_my_component_name() -> CInstruction {
@@ -188,10 +184,7 @@ pub fn my_component_name() -> CInstruction {
 
 pub const MY_FATHER: &str = "myFather";
 pub fn declare_my_father() -> CInstruction {
-    format!(
-        "u64 {} = {}->componentMemory[{}].idFather",
-        MY_FATHER, CIRCOM_CALC_WIT, CTX_INDEX
-    )
+    format!("u64 {} = {}->componentMemory[{}].idFather", MY_FATHER, CIRCOM_CALC_WIT, CTX_INDEX)
 }
 pub fn my_father() -> CInstruction {
     format!("{}", MY_FATHER)
@@ -199,10 +192,7 @@ pub fn my_father() -> CInstruction {
 
 pub const MY_ID: &str = "myId";
 pub fn declare_my_id() -> CInstruction {
-    format!(
-        "u64 {} = {}",
-        MY_ID, CTX_INDEX
-    )
+    format!("u64 {} = {}", MY_ID, CTX_INDEX)
 }
 pub fn my_id() -> CInstruction {
     format!("{}", MY_ID)
@@ -367,7 +357,7 @@ pub fn set_list(elems: Vec<usize>) -> String {
         set_string = format!("{}{},", set_string, elem);
     }
     set_string.pop();
-    set_string .push('}');
+    set_string.push('}');
     set_string
 }
 
@@ -385,23 +375,28 @@ pub fn add_return() -> String {
     "return;".to_string()
 }
 
-pub fn generate_my_array_position(aux_dimensions: String, len_dimensions: String, param: String) -> String {
-    format!("{}->generate_position_array({}, {}, {})", CIRCOM_CALC_WIT, aux_dimensions, len_dimensions, param)
+pub fn generate_my_array_position(
+    aux_dimensions: String,
+    len_dimensions: String,
+    param: String,
+) -> String {
+    format!(
+        "{}->generate_position_array({}, {}, {})",
+        CIRCOM_CALC_WIT, aux_dimensions, len_dimensions, param
+    )
 }
 
 pub fn generate_my_trace() -> String {
     format!("{}->getTrace({})", CIRCOM_CALC_WIT, MY_ID)
 }
 
-pub fn build_failed_assert_message(line: usize) -> String{
-    
+pub fn build_failed_assert_message(line: usize) -> String {
     format!("std::cout << \"Failed assert in template/function \" << {} << \" line {}. \" <<  \"Followed trace of components: \" << {} << std::endl" ,
         MY_TEMPLATE_NAME,
         line,
         generate_my_trace()
      )
 }
-
 
 pub fn build_conditional(
     cond: Vec<String>,
@@ -427,20 +422,21 @@ pub fn collect_template_headers(instances: &TemplateListParallel) -> Vec<String>
         let params_run = vec![declare_ctx_index(), declare_circom_calc_wit()];
         let params_run = argument_list(params_run);
         let params_create = vec![
-            declare_signal_offset(), 
-            declare_component_offset(), 
+            declare_signal_offset(),
+            declare_component_offset(),
             declare_circom_calc_wit(),
             declare_component_name(),
             declare_component_father(),
         ];
         let params_create = argument_list(params_create);
-        if instance.is_parallel{
+        if instance.is_parallel {
             let run_header = format!("void {}_run_parallel({});", instance.name, params_run);
-            let create_header = format!("void {}_create_parallel({});", instance.name, params_create);
+            let create_header =
+                format!("void {}_create_parallel({});", instance.name, params_create);
             template_headers.push(create_header);
             template_headers.push(run_header);
         }
-        if instance.is_not_parallel{
+        if instance.is_not_parallel {
             let run_header = format!("void {}_run({});", instance.name, params_run);
             let create_header = format!("void {}_create({});", instance.name, params_create);
             template_headers.push(create_header);
@@ -686,32 +682,35 @@ pub fn generate_dat_file(dat_file: &mut dyn Write, producer: &CProducer) -> std:
     */
     Ok(())
 }
-pub fn generate_function_list(_producer: &CProducer, list: &TemplateListParallel) -> (String, String) {
-    let mut func_list= "".to_string();
-    let mut func_list_parallel= "".to_string();
+pub fn generate_function_list(
+    _producer: &CProducer,
+    list: &TemplateListParallel,
+) -> (String, String) {
+    let mut func_list = "".to_string();
+    let mut func_list_parallel = "".to_string();
     if list.len() > 0 {
-        if list[0].is_parallel{
-            func_list_parallel.push_str(&format!("\n{}_run_parallel",list[0].name));
-        }else{
+        if list[0].is_parallel {
+            func_list_parallel.push_str(&format!("\n{}_run_parallel", list[0].name));
+        } else {
             func_list_parallel.push_str(&format!("\nNULL"));
         }
-        if list[0].is_not_parallel{
-            func_list.push_str(&format!("\n{}_run",list[0].name));
-        }else{
+        if list[0].is_not_parallel {
+            func_list.push_str(&format!("\n{}_run", list[0].name));
+        } else {
             func_list.push_str(&format!("\nNULL"));
         }
-	    for i in 1..list.len() {
-            if list[i].is_parallel{
-                func_list_parallel.push_str(&format!(",\n{}_run_parallel",list[i].name));
-            }else{
+        for i in 1..list.len() {
+            if list[i].is_parallel {
+                func_list_parallel.push_str(&format!(",\n{}_run_parallel", list[i].name));
+            } else {
                 func_list_parallel.push_str(&format!(",\nNULL"));
             }
-            if list[i].is_not_parallel{
-                func_list.push_str(&format!(",\n{}_run",list[i].name));
-            }else{
+            if list[i].is_not_parallel {
+                func_list.push_str(&format!(",\n{}_run", list[i].name));
+            } else {
                 func_list.push_str(&format!(",\nNULL"));
             }
-	    }
+        }
     }
     (func_list, func_list_parallel)
 }
@@ -734,9 +733,10 @@ pub fn generate_message_list_def(_producer: &CProducer, message_list: &MessageLi
     instructions
 }
 
-pub fn generate_function_release_memory_component() -> Vec<String>{
+pub fn generate_function_release_memory_component() -> Vec<String> {
     let mut instructions = vec![];
-    instructions.push("void release_memory_component(Circom_CalcWit* ctx, uint pos) {{\n".to_string());
+    instructions
+        .push("void release_memory_component(Circom_CalcWit* ctx, uint pos) {{\n".to_string());
     instructions.push("if (pos != 0){{\n".to_string());
     instructions.push("delete ctx->componentMemory[pos].subcomponents;\n".to_string());
     instructions.push("delete ctx->componentMemory[pos].subcomponentsParallel;\n".to_string());
@@ -749,7 +749,7 @@ pub fn generate_function_release_memory_component() -> Vec<String>{
     instructions
 }
 
-pub fn generate_function_release_memory_circuit() -> Vec<String>{ 
+pub fn generate_function_release_memory_circuit() -> Vec<String> {
     // deleting each one of the components
     let mut instructions = vec![];
     instructions.push("void release_memory(Circom_CalcWit* ctx) {{\n".to_string());
@@ -758,7 +758,7 @@ pub fn generate_function_release_memory_circuit() -> Vec<String>{
     instructions.push("}}\n".to_string());
     instructions.push("}}\n".to_string());
     instructions
-  }
+}
 
 pub fn generate_main_cpp_file(c_folder: &PathBuf) -> std::io::Result<()> {
     use std::io::BufWriter;
@@ -802,7 +802,7 @@ pub fn generate_fr_hpp_file(c_folder: &PathBuf, prime: &String) -> std::io::Resu
     let file_name = file_path.to_str().unwrap();
     let mut c_file = BufWriter::new(File::create(file_name).unwrap());
     let mut code = "".to_string();
-    let file = match prime.as_ref(){
+    let file = match prime.as_ref() {
         "bn128" => include_str!("bn128/fr.hpp"),
         "bls12381" => include_str!("bls12381/fr.hpp"),
         "goldilocks" => include_str!("goldilocks/fr.hpp"),
@@ -841,7 +841,7 @@ pub fn generate_fr_cpp_file(c_folder: &PathBuf, prime: &String) -> std::io::Resu
     let file_name = file_path.to_str().unwrap();
     let mut c_file = BufWriter::new(File::create(file_name).unwrap());
     let mut code = "".to_string();
-    let file = match prime.as_ref(){
+    let file = match prime.as_ref() {
         "bn128" => include_str!("bn128/fr.cpp"),
         "bls12381" => include_str!("bls12381/fr.cpp"),
         "goldilocks" => include_str!("goldilocks/fr.cpp"),
@@ -880,12 +880,12 @@ pub fn generate_fr_asm_file(c_folder: &PathBuf, prime: &String) -> std::io::Resu
     let file_name = file_path.to_str().unwrap();
     let mut c_file = BufWriter::new(File::create(file_name).unwrap());
     let mut code = "".to_string();
-    let file = match prime.as_ref(){
+    let file = match prime.as_ref() {
         "bn128" => include_str!("bn128/fr.asm"),
         "bls12381" => include_str!("bls12381/fr.asm"),
         "goldilocks" => include_str!("goldilocks/fr.asm"),
         _ => unreachable!(),
-    };    
+    };
     for line in file.lines() {
         code = format!("{}{}\n", code, line);
     }
@@ -937,7 +937,8 @@ pub fn generate_c_file(name: String, producer: &CProducer) -> std::io::Result<()
     let mut run_defs = collect_template_headers(producer.get_template_instance_list());
     code.append(&mut run_defs);
 
-    let (func_list_no_parallel, func_list_parallel) = generate_function_list(producer, producer.get_template_instance_list());
+    let (func_list_no_parallel, func_list_parallel) =
+        generate_function_list(producer, producer.get_template_instance_list());
 
     code.push(format!(
         "Circom_TemplateFunction _functionTable[{}] = {{ {} }};",
@@ -977,7 +978,7 @@ mod tests {
     use std::path::Path;
     //    use std::fs::File;
     use super::*;
-    const LOCATION: &'static str = "../target/code_generator_test";
+    const LOCATION: &'static str = "../target/c_code_generator_test";
 
     fn create_producer() -> CProducer {
         CProducer::default()

--- a/code_producers/src/wasm_elements/wasm_code_generator.rs
+++ b/code_producers/src/wasm_elements/wasm_code_generator.rs
@@ -226,7 +226,9 @@ pub fn get_initial_size_of_memory(producer: &WASMProducer) -> usize {
 
 //------------------- generate all kinds of Data ------------------
 
-pub fn generate_hash_map(signal_name_list: &Vec<(String, usize, usize)>) -> Vec<(u64, usize, usize)> {
+pub fn generate_hash_map(
+    signal_name_list: &Vec<(String, usize, usize)>,
+) -> Vec<(u64, usize, usize)> {
     assert!(signal_name_list.len() <= 256);
     let len = 256;
     let mut hash_map = vec![(0, 0, 0); len];
@@ -560,7 +562,7 @@ pub fn generate_data_list(producer: &WASMProducer) -> Vec<WasmInstruction> {
     wdata.push(format!(
         "(data (i32.const {}) \"{}\")",
         producer.get_raw_prime_start(),
-        wasm_hexa(producer.get_size_32_bit()*4, &p)
+        wasm_hexa(producer.get_size_32_bit() * 4, &p)
     ));
     wdata.push(format!(
         "(data (i32.const {}) \"{}\")",
@@ -579,7 +581,12 @@ pub fn generate_data_list(producer: &WASMProducer) -> Vec<WasmInstruction> {
         producer.get_witness_signal_id_list_start(),
         s
     ));
-    wdata.push(format!("(data (i32.const {}) \"{}{}\")",producer.get_signal_memory_start(),"\\00\\00\\00\\00\\00\\00\\00\\80",wasm_hexa(producer.get_size_32_bit()*4, &BigInt::from(1)))); //setting 'one' as long normal 1
+    wdata.push(format!(
+        "(data (i32.const {}) \"{}{}\")",
+        producer.get_signal_memory_start(),
+        "\\00\\00\\00\\00\\00\\00\\00\\80",
+        wasm_hexa(producer.get_size_32_bit() * 4, &BigInt::from(1))
+    )); //setting 'one' as long normal 1
     wdata.push(format!(
         "(data (i32.const {}) \"{}\")",
         producer.get_template_instance_to_io_signal_start(),
@@ -608,7 +615,7 @@ pub fn generate_data_list(producer: &WASMProducer) -> Vec<WasmInstruction> {
             wdata.push(format!(
                 "(data (i32.const {}) \"{}\\00\")",
                 m + i * producer.get_size_of_message_in_bytes(),
-                &ml[i][..producer.get_size_of_message_in_bytes()-1]
+                &ml[i][..producer.get_size_of_message_in_bytes() - 1]
             ));
         }
     }
@@ -625,7 +632,7 @@ pub fn generate_data_list(producer: &WASMProducer) -> Vec<WasmInstruction> {
             wdata.push(format!(
                 "(data (i32.const {}) \"{}\\00\")",
                 s + i * producer.get_size_of_message_in_bytes(),
-                &st[i][..producer.get_size_of_message_in_bytes()-1]
+                &st[i][..producer.get_size_of_message_in_bytes() - 1]
             ));
         }
     }
@@ -959,7 +966,7 @@ pub fn set_input_signal_generator(producer: &WASMProducer) -> Vec<WasmInstructio
     instructions.push(add_if()); // if 3
     instructions.push(set_constant(&exception_code_input_array_access_exeeds_size().to_string()));
     instructions.push(call("$exceptionHandler"));
-    instructions.push(add_else()); // else if 3    
+    instructions.push(add_else()); // else if 3
     instructions.push(get_local("$mp"));
     instructions.push(load32(Some("8"))); // load the first component (signal position)
     instructions.push(get_local("$pos"));
@@ -1028,7 +1035,7 @@ pub fn set_input_signal_generator(producer: &WASMProducer) -> Vec<WasmInstructio
     instructions.push(call(&funcname));
     instructions.push(tee_local(producer.get_merror_tag()));
     instructions.push(add_if()); // if 7
-    instructions.push(get_local("$merror"));    
+    instructions.push(get_local("$merror"));
     instructions.push(call("$exceptionHandler"));
     instructions.push(add_end()); // end if 7
     instructions.push(add_end()); // end if 6
@@ -1112,11 +1119,11 @@ pub fn copy_32_in_shared_rw_memory_generator(producer: &WASMProducer) -> Vec<Was
     instructions.push(set_constant(&producer.get_shared_rw_memory_start().to_string()));
     instructions.push(set_constant("0"));
     instructions.push(store32(Some("4")));
-    for i in 1..producer.get_size_32_bit()/2 {
-	let pos = 8*i;
-	instructions.push(set_constant(&producer.get_shared_rw_memory_start().to_string()));
-	instructions.push(set_constant_64("0"));
-	instructions.push(store64(Some(&pos.to_string())));
+    for i in 1..producer.get_size_32_bit() / 2 {
+        let pos = 8 * i;
+        instructions.push(set_constant(&producer.get_shared_rw_memory_start().to_string()));
+        instructions.push(set_constant_64("0"));
+        instructions.push(store64(Some(&pos.to_string())));
     }
     instructions.push(")".to_string());
     instructions
@@ -1149,7 +1156,7 @@ pub fn get_witness_generator(producer: &WASMProducer) -> Vec<WasmInstruction> {
     instructions.push(shl32());
     instructions.push(add32()); // address of the witness in the witness list
     instructions.push(load32(None)); // number of the signal in the signal Memory
-    instructions.push(set_constant(&format!("{}",producer.get_size_32_bit()*4+8)));//40
+    instructions.push(set_constant(&format!("{}", producer.get_size_32_bit() * 4 + 8))); //40
     instructions.push(mul32());
     instructions.push(set_constant(&producer.get_signal_memory_start().to_string()));
     instructions.push(add32()); // address of the signal in the signal Memory
@@ -1548,12 +1555,12 @@ fn get_file_instructions(name: &str) -> Vec<WasmInstruction> {
 
 pub fn fr_types(prime: &String) -> Vec<WasmInstruction> {
     let mut instructions = vec![];
-    let file = match prime.as_ref(){
+    let file = match prime.as_ref() {
         "bn128" => include_str!("bn128/fr-types.wat"),
         "bls12381" => include_str!("bls12381/fr-types.wat"),
         "goldilocks" => include_str!("goldilocks/fr-types.wat"),
         _ => unreachable!(),
-    };    
+    };
     for line in file.lines() {
         instructions.push(line.to_string());
     }
@@ -1562,12 +1569,12 @@ pub fn fr_types(prime: &String) -> Vec<WasmInstruction> {
 
 pub fn fr_data(prime: &String) -> Vec<WasmInstruction> {
     let mut instructions = vec![];
-    let file = match prime.as_ref(){
+    let file = match prime.as_ref() {
         "bn128" => include_str!("bn128/fr-data.wat"),
         "bls12381" => include_str!("bls12381/fr-data.wat"),
         "goldilocks" => include_str!("goldilocks/fr-data.wat"),
         _ => unreachable!(),
-    };    
+    };
     for line in file.lines() {
         instructions.push(line.to_string());
     }
@@ -1575,12 +1582,12 @@ pub fn fr_data(prime: &String) -> Vec<WasmInstruction> {
 }
 pub fn fr_code(prime: &String) -> Vec<WasmInstruction> {
     let mut instructions = vec![];
-    let file = match prime.as_ref(){
+    let file = match prime.as_ref() {
         "bn128" => include_str!("bn128/fr-code.wat"),
         "bls12381" => include_str!("bls12381/fr-code.wat"),
         "goldilocks" => include_str!("goldilocks/fr-code.wat"),
         _ => unreachable!(),
-    };    
+    };
     for line in file.lines() {
         instructions.push(line.to_string());
     }
@@ -1608,7 +1615,7 @@ pub fn generate_utils_js_file(js_folder: &PathBuf) -> std::io::Result<()> {
 
 pub fn generate_generate_witness_js_file(js_folder: &PathBuf) -> std::io::Result<()> {
     use std::io::BufWriter;
-    let mut file_path  = js_folder.clone();
+    let mut file_path = js_folder.clone();
     file_path.push("generate_witness");
     file_path.set_extension("js");
     let file_name = file_path.to_str().unwrap();
@@ -1625,7 +1632,7 @@ pub fn generate_generate_witness_js_file(js_folder: &PathBuf) -> std::io::Result
 
 pub fn generate_witness_calculator_js_file(js_folder: &PathBuf) -> std::io::Result<()> {
     use std::io::BufWriter;
-    let mut file_path  = js_folder.clone();
+    let mut file_path = js_folder.clone();
     file_path.push("witness_calculator");
     file_path.set_extension("js");
     let file_name = file_path.to_str().unwrap();
@@ -1645,7 +1652,7 @@ mod tests {
     use super::*;
     use std::io::{BufRead, BufReader, BufWriter, Write};
     use std::path::Path;
-    const LOCATION: &'static str = "../target/code_generator_test";
+    const LOCATION: &'static str = "../target/wasm_code_generator_test";
 
     fn create_producer() -> WASMProducer {
         WASMProducer::default()
@@ -1770,7 +1777,7 @@ mod tests {
 
         code_aux = build_log_message_generator(&producer);
         code.append(&mut code_aux);
-	
+
         //code_aux = main_sample_generator(&producer);
         //code.append(&mut code_aux);
 

--- a/program_structure/src/utils/memory_slice.rs
+++ b/program_structure/src/utils/memory_slice.rs
@@ -1,15 +1,15 @@
 use num_bigint_dig::BigInt;
 use std::fmt::{Display, Formatter};
 
-pub enum TypeInvalidAccess{
+pub enum TypeInvalidAccess {
     MissingInputs,
     NoInitializedComponent,
-    BadDimensions
+    BadDimensions,
 }
 
-pub enum TypeAssignmentError{
+pub enum TypeAssignmentError {
     MultipleAssignments,
-    AssignmentOutput
+    AssignmentOutput,
 }
 
 pub enum MemoryError {
@@ -24,7 +24,7 @@ pub enum MemoryError {
     AssignmentTagTwice,
     AssignmentTagInput,
     TagValueNotInitializedAccess,
-    MissingInputs(String)
+    MissingInputs(String),
 }
 pub type SliceCapacity = usize;
 pub type SimpleSlice = MemorySlice<BigInt>;
@@ -68,7 +68,6 @@ impl<C: Clone> MemorySlice<C> {
         memory_slice: &MemorySlice<C>,
         access: &[SliceCapacity],
     ) -> Result<SliceCapacity, MemoryError> {
-        
         if access.len() > memory_slice.route.len() {
             return Result::Err(MemoryError::OutOfBoundsError);
         }
@@ -92,13 +91,12 @@ impl<C: Clone> MemorySlice<C> {
         new_values: &MemorySlice<C>,
         is_strict: bool,
     ) -> Result<(), MemoryError> {
-
         if access.len() + new_values.route.len() > memory_slice.route.len() {
             return Result::Err(MemoryError::OutOfBoundsError);
         }
 
         let mut i: SliceCapacity = 0;
-        
+
         while i < access.len() {
             if access[i] >= memory_slice.route[i] {
                 return Result::Err(MemoryError::OutOfBoundsError);
@@ -111,9 +109,11 @@ impl<C: Clone> MemorySlice<C> {
 
         while i < new_values.route.len() {
             if new_values.route[i] < memory_slice.route[initial_index_new + i] {
-                if is_strict{ // case variables: we allow the assignment of smaller arrays
+                if is_strict {
+                    // case variables: we allow the assignment of smaller arrays
                     return Result::Err(MemoryError::MismatchedDimensions);
-                } else{ // case signals: we do not allow 
+                } else {
+                    // case signals: we do not allow
                     return Result::Err(MemoryError::MismatchedDimensionsWeak);
                 }
             }
@@ -190,9 +190,9 @@ impl<C: Clone> MemorySlice<C> {
         memory_slice: &mut MemorySlice<C>,
         access: &[SliceCapacity],
         new_values: &MemorySlice<C>,
-        is_strict:bool,
+        is_strict: bool,
     ) -> Result<(), MemoryError> {
-        match MemorySlice::check_correct_dims(memory_slice, access, new_values, is_strict){
+        match MemorySlice::check_correct_dims(memory_slice, access, new_values, is_strict) {
             Result::Ok(_) => {
                 let mut cell = MemorySlice::get_initial_cell(memory_slice, access)?;
 
@@ -206,7 +206,7 @@ impl<C: Clone> MemorySlice<C> {
                     cell += 1;
                 }
                 Result::Ok(())
-            },
+            }
             Result::Err(MemoryError::MismatchedDimensionsWeak) => {
                 let mut cell = MemorySlice::get_initial_cell(memory_slice, access)?;
                 // if MemorySlice::get_number_of_cells(new_values)
@@ -219,7 +219,7 @@ impl<C: Clone> MemorySlice<C> {
                     cell += 1;
                 }
                 Result::Err(MemoryError::MismatchedDimensionsWeak)
-            },
+            }
             Result::Err(error) => return Err(error),
         }
     }
@@ -228,7 +228,7 @@ impl<C: Clone> MemorySlice<C> {
         memory_slice: &mut MemorySlice<C>,
         index: usize,
         new_value: C,
-    )-> Result<(), MemoryError> {
+    ) -> Result<(), MemoryError> {
         if index > MemorySlice::get_number_of_cells(memory_slice) {
             return Result::Err(MemoryError::OutOfBoundsError);
         }
@@ -239,16 +239,15 @@ impl<C: Clone> MemorySlice<C> {
     pub fn get_access_index(
         memory_slice: &MemorySlice<C>,
         index: usize,
-    ) -> Result<Vec<SliceCapacity>, MemoryError>{
+    ) -> Result<Vec<SliceCapacity>, MemoryError> {
         let mut number_cells = MemorySlice::get_number_of_cells(memory_slice);
         if index > number_cells {
             return Result::Err(MemoryError::OutOfBoundsError);
-        }
-        else{
+        } else {
             let mut access = vec![];
             let mut index_aux = index;
-            for pos in &memory_slice.route{
-                number_cells = number_cells/pos;
+            for pos in &memory_slice.route {
+                number_cells = number_cells / pos;
                 access.push(index_aux / number_cells);
                 index_aux = index_aux % number_cells;
             }
@@ -265,7 +264,7 @@ impl<C: Clone> MemorySlice<C> {
     pub fn access_value_by_index(
         memory_slice: &MemorySlice<C>,
         index: usize,
-    )-> Result<C, MemoryError> {
+    ) -> Result<C, MemoryError> {
         if index > MemorySlice::get_number_of_cells(memory_slice) {
             return Result::Err(MemoryError::OutOfBoundsError);
         }
@@ -373,7 +372,7 @@ mod tests {
         let mut slice = U32Slice::new_with_route(&route, &0);
         let new_row = U32Slice::new_with_route(&[4], &4);
 
-        let res = U32Slice::insert_values(&mut slice, &[2], &new_row);
+        let res = U32Slice::insert_values(&mut slice, &[2], &new_row, true);
         if let Result::Ok(_) = res {
             for c in 0..4 {
                 let memory_result = U32Slice::get_reference_to_single_value(&slice, &[2, c]);


### PR DESCRIPTION
This pull request contains the following unit test fixes:

* Fix for `memory_slice_multiple_insertion` test - an argument in `U32Slice::insert_values()` method was missing.
* Fix for a race condition between C and WASM tests. Both C and WASM tests were attempting to create the `../target/code_generator_test` directory. Rust runs tests in multiple threads in parallel, so those tests were often failing with the following error:

```
---- wasm_elements::wasm_code_generator::tests::produce_code stdout ----
thread 'wasm_elements::wasm_code_generator::tests::produce_code' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 17, kind: AlreadyExists, message: "File exists" }', code_producers/src/wasm_elements/wasm_code_generator.rs:1656:43
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The fix is to use different directories for C and WASM tests.