### PR TITLE
fix generate_function_release_memory_component function

### DIFF
--- a/code_producers/src/c_elements/c_code_generator.rs
+++ b/code_producers/src/c_elements/c_code_generator.rs
@@ -738,12 +738,18 @@ pub fn generate_function_release_memory_component() -> Vec<String>{
     let mut instructions = vec![];
     instructions.push("void release_memory_component(Circom_CalcWit* ctx, uint pos) {{\n".to_string());
     instructions.push("if (pos != 0){{\n".to_string());
-    instructions.push("delete ctx->componentMemory[pos].subcomponents;\n".to_string());
-    instructions.push("delete ctx->componentMemory[pos].subcomponentsParallel;\n".to_string());
-    instructions.push("delete ctx->componentMemory[pos].outputIsSet;\n".to_string());
-    instructions.push("delete ctx->componentMemory[pos].mutexes;\n".to_string());
-    instructions.push("delete ctx->componentMemory[pos].cvs;\n".to_string());
-    instructions.push("delete ctx->componentMemory[pos].sbct;\n".to_string());
+    instructions.push("if(ctx->componentMemory[pos].subcomponents)".to_string());
+    instructions.push("delete []ctx->componentMemory[pos].subcomponents;\n".to_string());
+    instructions.push("if(ctx->componentMemory[pos].subcomponentsParallel)".to_string());
+    instructions.push("delete []ctx->componentMemory[pos].subcomponentsParallel;\n".to_string());
+    instructions.push("if(ctx->componentMemory[pos].outputIsSet)".to_string());
+    instructions.push("delete []ctx->componentMemory[pos].outputIsSet;\n".to_string());
+    instructions.push("if(ctx->componentMemory[pos].mutexes)".to_string());
+    instructions.push("delete []ctx->componentMemory[pos].mutexes;\n".to_string());
+    instructions.push("if(ctx->componentMemory[pos].cvs)".to_string());
+    instructions.push("delete []ctx->componentMemory[pos].cvs;\n".to_string());
+    instructions.push("if(ctx->componentMemory[pos].sbct)".to_string());
+    instructions.push("delete []ctx->componentMemory[pos].sbct;\n".to_string());
     instructions.push("}}\n\n".to_string());
     instructions.push("}}\n\n".to_string());
     instructions

--- a/code_producers/src/c_elements/common/circom.hpp
+++ b/code_producers/src/c_elements/common/circom.hpp
@@ -47,12 +47,12 @@ struct Circom_Component {
   std::string templateName;
   std::string componentName;
   u64 idFather; 
-  u32* subcomponents;
-  bool* subcomponentsParallel;
-  bool *outputIsSet;  //one for each output
-  std::mutex *mutexes;  //one for each output
-  std::condition_variable *cvs;
-  std::thread *sbct; //subcomponent threads
+  u32* subcomponents = NULL;
+  bool* subcomponentsParallel = NULL;
+  bool *outputIsSet = NULL;  //one for each output
+  std::mutex *mutexes = NULL;  //one for each output
+  std::condition_variable *cvs = NULL;
+  std::thread *sbct = NULL;//subcomponent threads
 };
 
 /*


### PR DESCRIPTION
The code generated for C++ when using parallel components produces a core dump:

```
./final ~/zkevm-prover/final_proof.zkin.json final.wtns
munmap_chunk(): invalid pointer
Aborted (core dumped)
```

This is due to how memory is freed, I have converted the deletes to array, added a check to avoid freeing if they have not been allocated, and also the initialisation of the pointers to null, this seems to fix the problem