### PR TITLE
bug fix: cover NonCompatibleBranchTypes

### DIFF
--- a/type_analysis/src/analyzers/type_check.rs
+++ b/type_analysis/src/analyzers/type_check.rs
@@ -1068,7 +1068,8 @@ fn add_report(error_code: ReportCode, meta: &Meta, reports: &mut ReportCollectio
             format!("Expecting {} arguments, {} where obtained", expected, got)
         }
         UninitializedComponent => "Trying to access to a signal of a component that has not been initialized".to_string(),
-        _ => panic!("Unimplemented error code"),
+        NonCompatibleBranchTypes => "Inline switch operator branches types are non compatible".to_string(),
+        e => panic!("Unimplemented error code: {}", e),
     };
     report.add_primary(location, file_id, message);
     reports.push(report);


### PR DESCRIPTION
It seems that the report code NonCompatibleBranchTypes was accidentally not covered. I checked if any other report codes were left out and as far as I can tell this is the only one.

The following code causes Circom to panic

## How to reproduce the bug:

### a.circom
```circom
pragma circom 2.1.5;

function A(t) {
    return t == 1 ? [1, 2, 3] : 4;
}
```

### b.circom
```circom
pragma circom 2.1.5;

include "./a.circom";

template B() {
    var a0[3] = A(1);
}

component main = B();
```

run:
```
circom b.circom
```