### PR TITLE
Move subcomponent counter decrease operation outside of assert

### DIFF
--- a/compiler/src/intermediate_representation/call_bucket.rs
+++ b/compiler/src/intermediate_representation/call_bucket.rs
@@ -496,16 +496,20 @@ impl WriteC for CallBucket {
                 match &data.dest_address_type {
                     AddressType::SubcmpSignal { uniform_parallel_value, input_information, .. } => {
                         // if subcomponent input check if run needed
-			let sub_cmp_counter_decrease = format!(
-			    "{}->componentMemory[{}[{}]].inputCounter -= {}",
-			    CIRCOM_CALC_WIT, MY_SUBCOMPONENTS, cmp_index_ref, &data.context.size
-			);
+                        let sub_cmp_counter = format!(
+                            "{}->componentMemory[{}[{}]].inputCounter",
+                            CIRCOM_CALC_WIT, MY_SUBCOMPONENTS, cmp_index_ref
+                        );
+                        let sub_cmp_counter_decrease = format!(
+                            "{} -= {}",
+                            sub_cmp_counter, &data.context.size
+                        );
 			if let InputInformation::Input{status} = input_information {
 			    if let StatusInput::NoLast = status {
 				// no need to run subcomponent
 				prologue.push("// no need to run sub component".to_string());
-				//prologue.push(format!("{};",sub_cmp_counter_decrease));
-				prologue.push(format!("assert({});",sub_cmp_counter_decrease));
+				prologue.push(format!("{};", sub_cmp_counter_decrease));
+				prologue.push(format!("assert({} > 0);", sub_cmp_counter));
 			    } else {
 				let sub_cmp_pos = format!("{}[{}]", MY_SUBCOMPONENTS, cmp_index_ref);
 				let sub_cmp_call_arguments =
@@ -551,7 +555,8 @@ impl WriteC for CallBucket {
                         prologue.push(build_conditional(if_condition,call_instructions,else_instructions));
                     } else {
                         prologue.push("// need to run sub component".to_string());
-                        prologue.push(format!("assert(!({}));",sub_cmp_counter_decrease));
+                        prologue.push(format!("{};", sub_cmp_counter_decrease));
+                        prologue.push(format!("assert(!({}));", sub_cmp_counter));
                         prologue.append(&mut call_instructions);
                     }
                 }
@@ -584,7 +589,8 @@ impl WriteC for CallBucket {
                         prologue.push(build_conditional(if_condition,call_instructions,else_instructions));
                     } else {
                         prologue.push("// need to run sub component".to_string());
-                        prologue.push(format!("assert(!({}));",sub_cmp_counter_decrease));
+                        prologue.push(format!("{};", sub_cmp_counter_decrease));
+                        prologue.push(format!("assert(!({}));", sub_cmp_counter));
                         prologue.append(&mut call_instructions);
                     }
                     // end of case parallel
@@ -609,7 +615,8 @@ impl WriteC for CallBucket {
                         prologue.push(build_conditional(if_condition,call_instructions,else_instructions));
                     } else {
                         prologue.push("// need to run sub component".to_string());
-                        prologue.push(format!("assert(!({}));",sub_cmp_counter_decrease));
+                        prologue.push(format!("{};", sub_cmp_counter_decrease));
+                        prologue.push(format!("assert(!({}));", sub_cmp_counter));
                         prologue.append(&mut call_instructions);
                     }
 

--- a/compiler/src/intermediate_representation/store_bucket.rs
+++ b/compiler/src/intermediate_representation/store_bucket.rs
@@ -405,16 +405,20 @@ impl WriteC for StoreBucket {
         match &self.dest_address_type {
             AddressType::SubcmpSignal{ uniform_parallel_value, input_information, .. } => {
                 // if subcomponent input check if run needed
+                let sub_cmp_counter = format!(
+                    "{}->componentMemory[{}[{}]].inputCounter",
+                    CIRCOM_CALC_WIT, MY_SUBCOMPONENTS, cmp_index_ref
+                );
                 let sub_cmp_counter_decrease = format!(
-                    "{}->componentMemory[{}[{}]].inputCounter -= {}",
-                    CIRCOM_CALC_WIT, MY_SUBCOMPONENTS, cmp_index_ref, self.context.size
+                    "{} -= {}",
+                    sub_cmp_counter, self.context.size
                 );
 		if let InputInformation::Input{status} = input_information {
 		    if let StatusInput::NoLast = status {
 			// no need to run subcomponent
 			prologue.push("// no need to run sub component".to_string());
-			//prologue.push(format!("{};",sub_cmp_counter_decrease));
-			prologue.push(format!("assert({});",sub_cmp_counter_decrease));
+			prologue.push(format!("{};", sub_cmp_counter_decrease));
+			prologue.push(format!("assert({} > 0);", sub_cmp_counter));
 		    } else {
 			let sub_cmp_pos = format!("{}[{}]", MY_SUBCOMPONENTS, cmp_index_ref);
 			let sub_cmp_call_arguments =
@@ -458,7 +462,8 @@ impl WriteC for StoreBucket {
                     prologue.push(build_conditional(if_condition,call_instructions,else_instructions));
                 } else {
                     prologue.push("// need to run sub component".to_string());
-                    prologue.push(format!("assert(!({}));",sub_cmp_counter_decrease));
+                    prologue.push(format!("{};", sub_cmp_counter_decrease));
+                    prologue.push(format!("assert(!({}));", sub_cmp_counter));
                     prologue.append(&mut call_instructions);
                 }
             }
@@ -491,7 +496,8 @@ impl WriteC for StoreBucket {
                     prologue.push(build_conditional(if_condition,call_instructions,else_instructions));
                 } else {
                     prologue.push("// need to run sub component".to_string());
-                    prologue.push(format!("assert(!({}));",sub_cmp_counter_decrease));
+                    prologue.push(format!("{};", sub_cmp_counter_decrease));
+                    prologue.push(format!("assert(!({}));", sub_cmp_counter));
                     prologue.append(&mut call_instructions);
                 }
                 // end of case parallel
@@ -516,7 +522,8 @@ impl WriteC for StoreBucket {
                     prologue.push(build_conditional(if_condition,call_instructions,else_instructions));
                 } else {
                     prologue.push("// need to run sub component".to_string());
-                    prologue.push(format!("assert(!({}));",sub_cmp_counter_decrease));
+                    prologue.push(format!("{};", sub_cmp_counter_decrease));
+                    prologue.push(format!("assert(!({}));", sub_cmp_counter));
                     prologue.append(&mut call_instructions);
                 }
                 // end of not parallel case


### PR DESCRIPTION
In some cases asserts are disabled by cpp compiler and operation (subcomponent counter decrease) is not executed.

Fixes the problem with cpp witnesscalc reported here: https://github.com/0xPolygonID/witnesscalc/issues/4#issuecomment-1561302651

In general would be good to switch from asserts to exceptions I think.