### PR TITLE
Update testnets

### DIFF
--- a/mkdocs/docs/getting-started/proving-circuits.md
+++ b/mkdocs/docs/getting-started/proving-circuits.md
@@ -146,7 +146,7 @@ snarkjs zkey export solidityverifier multiplier2_0001.zkey verifier.sol
 
 This command takes validation key `multiplier2_0001.zkey` and outputs Solidity code in a file named `verifier.sol`. You can take the code from this file and cut and paste it in Remix. You will see that the code contains two contracts: `Pairing` and `Verifier`. You only need to deploy the `Verifier` contract.
 
-You may want to use first a testnet like Rinkeby, Kovan or Ropsten. You can also use the JavaScript VM, but in some browsers the verification takes long and the page may freeze.
+You may want to use first a testnet like Goerli or Sepolia. You can also use the JavaScript VM, but in some browsers the verification takes long and the page may freeze.
 
 The `Verifier` has a `view` function called `verifyProof` that returns `TRUE` if and only if the proof and the inputs are valid. To facilitate the call, you can use `snarkJS` to generate the parameters of the call by typing:
 


### PR DESCRIPTION
This PR updates the example testnets to Goerli and Sepolia.

Rinkeby, Kovan, and Ropsten are all deprecated now and Remix only shows Goerli and Sepolia.