### PR TITLE
Allow duplicate but equal templates/functions

### DIFF
--- a/program_structure/src/program_library/function_data.rs
+++ b/program_structure/src/program_library/function_data.rs
@@ -10,7 +10,7 @@ pub struct FunctionData {
     name: String,
     file_id: FileID,
     num_of_params: usize,
-    name_of_params: Vec<String>,
+    pub name_of_params: Vec<String>,
     param_location: FileLocation,
     body: Statement,
 }

--- a/program_structure/src/program_library/template_data.rs
+++ b/program_structure/src/program_library/template_data.rs
@@ -15,15 +15,15 @@ pub struct TemplateData {
     name: String,
     body: Statement,
     num_of_params: usize,
-    name_of_params: Vec<String>,
+    pub name_of_params: Vec<String>,
     param_location: FileLocation,
     input_signals: SignalInfo,
     output_signals: SignalInfo,
     is_parallel: bool,
     is_custom_gate: bool,
     /* Only used to know the order in which signals are declared.*/
-    input_declarations: SignalDeclarationOrder,
-    output_declarations: SignalDeclarationOrder,
+    pub input_declarations: SignalDeclarationOrder,
+    pub output_declarations: SignalDeclarationOrder,
 }
 
 impl TemplateData {


### PR DESCRIPTION
Hello,

So I don't have much experience with Rust but I was able to come up with this patch for my issue #225.

I would imagine that it may be better if it compares the template/function bodies but I couldn't figure out how to get the equality to work on the `ast::Statement` type.