### PR TITLE
feat: make circom as a lib and makesub module public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "circom"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "ansi_term",
  "clap",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "code_producers"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "handlebars",
  "lz_fnv",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "compiler"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "code_producers",
  "constant_tracking",
@@ -190,7 +190,7 @@ version = "2.0.0"
 
 [[package]]
 name = "constraint_generation"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "ansi_term",
  "circom_algebra",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "constraint_list"
-version = "2.1.5"
+version = "2.1.7"
 dependencies = [
  "circom_algebra",
  "constraint_writers",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "constraint_writers"
-version = "2.1.5"
+version = "2.1.7"
 dependencies = [
  "circom_algebra",
  "json",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "dag"
-version = "2.1.5"
+version = "2.1.7"
 dependencies = [
  "circom_algebra",
  "constraint_list",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "parser"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "program_structure"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "type_analysis"
-version = "2.1.5"
+version = "2.1.7"
 dependencies = [
  "num-bigint-dig",
  "num-traits",

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -1,8 +1,8 @@
-mod compilation_user;
-mod execution_user;
-mod input_user;
-mod parser_user;
-mod type_analysis_user;
+pub mod compilation_user;
+pub mod execution_user;
+pub mod input_user;
+pub mod parser_user;
+pub mod type_analysis_user;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
@@ -42,7 +42,7 @@ fn start() -> Result<(), ()> {
         sym: user_input.sym_file().to_string(),
         r1cs: user_input.r1cs_file().to_string(),
         json_constraints: user_input.json_constraints_file().to_string(),
-        prime: user_input.prime(),        
+        prime: user_input.prime(),
     };
     let circuit = execution_user::execute_project(program_archive, config)?;
     let compilation_config = CompilerConfig {


### PR DESCRIPTION
This PR does two things:

1) created `circom/lib.rs`
2) make submodule of circom public.

Which make `circom` can be integrated into other Rust crates.