### PR TITLE
Apply clippy fixes

### DIFF
--- a/circom/src/compilation_user.rs
+++ b/circom/src/compilation_user.rs
@@ -43,17 +43,9 @@ pub fn compile(config: CompilerConfig) -> Result<(), ()> {
                 config.dat_file
             );
             println!(
-                "{} {}/{}, {}, {}, {}, {}, {}, {} and {}",
+                "{} {}/main.cpp, circom.hpp, calcwit.hpp, calcwit.cpp, fr.hpp, fr.cpp, fr.asm and Makefile",
                 Colour::Green.paint("Written successfully:"),
-            &config.c_folder,
-                "main.cpp".to_string(),
-                "circom.hpp".to_string(),
-                "calcwit.hpp".to_string(),
-                "calcwit.cpp".to_string(),
-                "fr.hpp".to_string(),
-                "fr.cpp".to_string(),
-                "fr.asm".to_string(),
-                "Makefile".to_string()
+            &config.c_folder
             );
         }
     

--- a/circom/src/compilation_user.rs
+++ b/circom/src/compilation_user.rs
@@ -56,7 +56,7 @@ pub fn compile(config: CompilerConfig) -> Result<(), ()> {
                 let result = wat_to_wasm(&config.wat_file, &config.wasm_file);
                 match result {
                     Result::Err(report) => {
-                        Report::print_reports(&[report], &FileLibrary::new());
+                        Report::print_reports(&[*report], &FileLibrary::new());
                         return Err(());
                     }
                     Result::Ok(()) => {
@@ -70,7 +70,7 @@ pub fn compile(config: CompilerConfig) -> Result<(), ()> {
                 std::fs::remove_file(&config.wat_file).unwrap();
                 match result {
                     Result::Err(report) => {
-                        Report::print_reports(&[report], &FileLibrary::new());
+                        Report::print_reports(&[*report], &FileLibrary::new());
                         return Err(());
                     }
                     Result::Ok(()) => {
@@ -91,7 +91,7 @@ pub fn compile(config: CompilerConfig) -> Result<(), ()> {
 }
 
 
-fn wat_to_wasm(wat_file: &str, wasm_file: &str) -> Result<(), Report> {
+fn wat_to_wasm(wat_file: &str, wasm_file: &str) -> Result<(), Box<Report>> {
     use std::fs::read_to_string;
     use std::fs::File;
     use std::io::BufWriter;
@@ -104,19 +104,19 @@ fn wat_to_wasm(wat_file: &str, wasm_file: &str) -> Result<(), Report> {
     let result_wasm_contents = parser::parse::<Wat>(&buf);
     match result_wasm_contents {
         Result::Err(error) => {
-            Result::Err(Report::error(
+            Result::Err(Box::new(Report::error(
                 format!("Error translating the circuit from wat to wasm.\n\nException encountered when parsing WAT: {}", error),
                 ReportCode::ErrorWat2Wasm,
-            ))
+            )))
         }
         Result::Ok(mut wat) => {
             let wasm_contents = wat.module.encode();
             match wasm_contents {
                 Result::Err(error) => {
-                    Result::Err(Report::error(
+                    Result::Err(Box::new(Report::error(
                         format!("Error translating the circuit from wat to wasm.\n\nException encountered when encoding WASM: {}", error),
                         ReportCode::ErrorWat2Wasm,
-                    ))
+                    )))
                 }
                 Result::Ok(wasm_contents) => {
                     let file = File::create(wasm_file).unwrap();

--- a/circom/src/execution_user.rs
+++ b/circom/src/execution_user.rs
@@ -80,7 +80,7 @@ fn generate_json_constraints(
     debug: &DebugWriter,
     exporter: &dyn ConstraintExporter,
 ) -> Result<(), ()> {
-    if let Ok(()) = exporter.json_constraints(&debug) {
+    if let Ok(()) = exporter.json_constraints(debug) {
         println!("{} {}", Colour::Green.paint("Constraints written in:"), debug.json_constraints);
         Result::Ok(())
     } else {

--- a/circom/src/input_user.rs
+++ b/circom/src/input_user.rs
@@ -36,14 +36,14 @@ pub struct Input {
 }
 
 
-const R1CS: &'static str = "r1cs";
-const WAT: &'static str = "wat";
-const WASM: &'static str = "wasm";
-const CPP: &'static str = "cpp";
-const JS: &'static str = "js";
-const DAT: &'static str = "dat";
-const SYM: &'static str = "sym";
-const JSON: &'static str = "json";
+const R1CS: &str = "r1cs";
+const WAT: &str = "wat";
+const WASM: &str = "wasm";
+const CPP: &str = "cpp";
+const JS: &str = "js";
+const DAT: &str = "dat";
+const SYM: &str = "sym";
+const JSON: &str = "json";
 
 
 impl Input {
@@ -90,7 +90,7 @@ impl Input {
             ),
             wat_flag:input_processing::get_wat(&matches),
             wasm_flag: input_processing::get_wasm(&matches),
-            c_flag: c_flag,
+            c_flag,
             r1cs_flag: input_processing::get_r1cs(&matches),
             sym_flag: input_processing::get_sym(&matches),
             main_inputs_flag: input_processing::get_main_inputs_log(&matches),
@@ -127,7 +127,7 @@ impl Input {
     }
 
     pub fn input_file(&self) -> &str {
-        &self.input_program.to_str().unwrap()
+        self.input_program.to_str().unwrap()
     }
     pub fn r1cs_file(&self) -> &str {
         self.out_r1cs.to_str().unwrap()

--- a/circom/src/input_user.rs
+++ b/circom/src/input_user.rs
@@ -109,6 +109,7 @@ impl Input {
         })
     }
 
+    #[allow(clippy::ptr_arg)]
     fn build_folder(output_path: &PathBuf, filename: &str, ext: &str) -> PathBuf {
         let mut file = output_path.clone();
 	    let folder_name = format!("{}_{}",filename,ext);
@@ -116,6 +117,7 @@ impl Input {
 	    file
     }
     
+    #[allow(clippy::ptr_arg)]
     fn build_output(output_path: &PathBuf, filename: &str, ext: &str) -> PathBuf {
         let mut file = output_path.clone();
         file.push(format!("{}.{}",filename,ext));
@@ -257,7 +259,7 @@ mod input_processing {
             (_, true, _, _) => Ok(SimplificationStyle::O1),
             (_, _, true,  _) => {
                 let o_2_argument = matches.value_of("simplification_rounds").unwrap();
-                let rounds_r = usize::from_str_radix(o_2_argument, 10);
+                let rounds_r = o_2_argument.parse::<usize>();
                 if let Result::Ok(no_rounds) = rounds_r { 
                     if no_rounds == 0 { Ok(SimplificationStyle::O1) }
                     else {Ok(SimplificationStyle::O2(no_rounds))}} 

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -4,7 +4,7 @@ mod input_user;
 mod parser_user;
 mod type_analysis_user;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 
 use ansi_term::Colour;

--- a/circom_algebra/src/algebra.rs
+++ b/circom_algebra/src/algebra.rs
@@ -1218,6 +1218,7 @@ impl Constraint<usize> {
         let c = apply_raw_offset(&self.c, offset);
         Constraint::new(a, b, c)
     }
+    #[allow(clippy::ptr_arg)]
     pub fn apply_witness(&self, witness: &Vec<usize>) -> Constraint<usize> {
         let a = apply_vectored_correspondence(&self.a, witness);
         let b = apply_vectored_correspondence(&self.b, witness);
@@ -1231,7 +1232,7 @@ type RawExpr<C> = HashMap<C, BigInt>;
 
 fn apply_vectored_correspondence(
     symbols: &HashMap<usize, BigInt>,
-    map: &Vec<usize>,
+    map: &[usize],
 ) -> HashMap<usize, BigInt> {
     let mut mapped = HashMap::new();
     for (s, v) in symbols {

--- a/circom_algebra/src/constraint_storage/mod.rs
+++ b/circom_algebra/src/constraint_storage/mod.rs
@@ -19,6 +19,12 @@ pub struct ConstraintStorage {
     constraints: Vec<CompressedConstraint>,
 }
 
+impl Default for ConstraintStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ConstraintStorage {
     pub fn new() -> ConstraintStorage {
         ConstraintStorage { field_tracker: FieldTracker::new(), constraints: Vec::new() }

--- a/circom_algebra/src/modular_arithmetic.rs
+++ b/circom_algebra/src/modular_arithmetic.rs
@@ -41,7 +41,7 @@ pub fn sub(left: &BigInt, right: &BigInt, field: &BigInt) -> BigInt {
 pub fn div(left: &BigInt, right: &BigInt, field: &BigInt) -> Result<BigInt, ArithmeticError> {
     let right_inverse = right
         .mod_inverse(field)
-        .map_or(Result::Err(ArithmeticError::DivisionByZero), |a| Result::Ok(a))?;
+        .map_or(Result::Err(ArithmeticError::DivisionByZero), Result::Ok)?;
     let res = mul(left, &right_inverse, field);
     Result::Ok(res)
 }
@@ -73,21 +73,21 @@ pub fn multi_inv(values: &Vec<BigInt>, field: &BigInt) -> Vec<BigInt>{
     let mut partials : Vec<BigInt> = Vec::new();
     partials.push(one.clone());
     for i in 0..values.len(){
-        partials.push(mul(partials.get(partials.len()-1).unwrap(),
+        partials.push(mul(partials.last().unwrap(),
                                           values.get(i).unwrap(),
-                                          &field));
+                                          field));
     }
     let mut inverse = div(&one,
-                   partials.get(partials.len()-1).unwrap(),
-                   &field).ok().unwrap();
+                   partials.last().unwrap(),
+                   field).ok().unwrap();
     let mut outputs : Vec<BigInt> = vec![BigInt::from(0); partials.len()];
     let mut i = values.len();
     while i > 0{
-        outputs[i-1] = mul(partials.get(i-1).unwrap(), &inverse, &field);
-        inverse = mul(&inverse, values.get(i-1).unwrap(), &field);
-        i = i - 1;
+        outputs[i-1] = mul(partials.get(i-1).unwrap(), &inverse, field);
+        inverse = mul(&inverse, values.get(i-1).unwrap(), field);
+        i -= 1;
     }
-    return outputs;
+    outputs
 }
 
 //Bit operations
@@ -114,7 +114,7 @@ pub fn shift_l(left: &BigInt, right: &BigInt, field: &BigInt) -> Result<BigInt, 
     if right <= &top {
         let usize_repr = right
             .to_usize()
-            .map_or(Result::Err(ArithmeticError::DivisionByZero), |a| Result::Ok(a))?;
+            .map_or(Result::Err(ArithmeticError::DivisionByZero), Result::Ok)?;
         let value = modulus(&((left * &num_traits::pow(two, usize_repr)) & &mask(field)), field);
         Result::Ok(value)
     } else {
@@ -127,7 +127,7 @@ pub fn shift_r(left: &BigInt, right: &BigInt, field: &BigInt) -> Result<BigInt, 
     if right <= &top {
         let usize_repr = right
             .to_usize()
-            .map_or(Result::Err(ArithmeticError::DivisionByZero), |a| Result::Ok(a))?;
+            .map_or(Result::Err(ArithmeticError::DivisionByZero), Result::Ok)?;
         let value = left / &num_traits::pow(two, usize_repr);
         Result::Ok(value)
     } else {

--- a/circom_algebra/src/modular_arithmetic.rs
+++ b/circom_algebra/src/modular_arithmetic.rs
@@ -243,7 +243,7 @@ mod tests {
         if let Result::Ok(res) = mod_op(&a, &b, &field) {
             assert_eq!(a, res)
         } else {
-            assert!(false);
+            unreachable!();
         }
     }
     #[test]

--- a/circom_algebra/src/simplification_utils.rs
+++ b/circom_algebra/src/simplification_utils.rs
@@ -72,7 +72,7 @@ impl SignalsInformation {
                 if signals.can_be_taken(*k) {
                     match signal_to_ocurrences.get_mut(k){
                         Some(prev_ocu) =>{
-                            *prev_ocu = *prev_ocu + 1;
+                            *prev_ocu += 1;
                         },
                         None => {
                             signal_to_ocurrences.insert(*k, 1);
@@ -94,9 +94,9 @@ impl SignalsInformation {
     pub fn remove_constraint(&mut self, constraint: &C, signals: &SignalDefinition4){
         for signal in constraint.c().keys(){
             if signals.can_be_taken(*signal){
-                match self.signal_to_ocurrences.get_mut(&signal){
+                match self.signal_to_ocurrences.get_mut(signal){
                     Some(ocurrences) =>{
-                        *ocurrences = *ocurrences - 1;
+                        *ocurrences -= 1;
                     },
                     None => {},
                 }
@@ -204,7 +204,7 @@ fn treat_constraint_1(
         let out = out.unwrap();
         signals.delete(out);
         let substitution = C::clear_signal_from_linear(work, &out, field);
-        let in_conflict = substitutions.get(&substitution.from()).cloned();
+        let in_conflict = substitutions.get(substitution.from()).cloned();
         if in_conflict.is_none() {
             substitutions.insert(*substitution.from(), substitution);
             break;
@@ -238,7 +238,7 @@ fn treat_constraint_2(
         let out = out.unwrap();
         signals.delete(out);
         let (coefficient, substitution) = C::clear_signal_from_linear_not_normalized(work, &out, field);
-        let in_conflict = substitutions.get(&substitution.from()).cloned();
+        let in_conflict = substitutions.get(substitution.from()).cloned();
         if in_conflict.is_none() {
             substitutions.insert(*substitution.from(), (coefficient, substitution));
             break;
@@ -275,7 +275,7 @@ fn treat_constraint_3(
         let out = out.unwrap();
         signals.delete(out);
         let (coefficient, substitution) = C::clear_signal_from_linear_not_normalized(work, &out, field);
-        let in_conflict = substitutions.get(&substitution.from()).cloned();
+        let in_conflict = substitutions.get(substitution.from()).cloned();
         if in_conflict.is_none() {
             substitutions.insert(*substitution.from(), (coefficient, substitution));
             break;
@@ -328,7 +328,7 @@ fn treat_constraint_4(
         }
         let out = out.unwrap();
         let (coefficient, substitution) = C::clear_signal_from_linear_not_normalized(work, &out, field);
-        let in_conflict = substitutions.get(&substitution.from()).cloned();
+        let in_conflict = substitutions.get(substitution.from()).cloned();
         if in_conflict.is_none() {
             signals.delete(out);
             info_ocurrences.remove_signal(out);
@@ -393,10 +393,8 @@ fn take_signal_4(signals: &SignalDefinition4, info_ocurrences: &SignalsInformati
                             ret = Some(*k);
                             ocurrences_ret = Some(*new_ocurrences);
                         }
-                        else if *new_ocurrences == val_ant{
-                            if ret.unwrap() < *k{
-                                ret = Some(*k);
-                            }
+                        else if *new_ocurrences == val_ant && ret.unwrap() < *k {
+                            ret = Some(*k);
                         }
                     },
                     None => {
@@ -429,9 +427,9 @@ fn normalize_substitutions(substitutions: SHNotNormalized, field: &BigInt) -> SH
             &A::Number {value : inv.clone()}, 
             field
         );
-        let new_sub = S::new(signal.clone(), mult_by_inverse).unwrap(); 
+        let new_sub = S::new(signal, mult_by_inverse).unwrap(); 
         tree.insert(signal, new_sub);
-        i = i + 1;
+        i += 1;
     }
     tree
 }

--- a/circom_algebra/src/simplification_utils.rs
+++ b/circom_algebra/src/simplification_utils.rs
@@ -62,18 +62,18 @@ struct SignalsInformation {
 }
 
 impl SignalsInformation {
-
+    #[allow(clippy::ptr_arg)]
     pub fn new(constraints: &Vec<C>, signals: &SignalDefinition4, num_signals: usize) -> (SignalsInformation, BTreeMap<usize, usize>) {
         let mut signal_to_ocurrences: HashMap<usize, usize> = HashMap::with_capacity(num_signals);
         let mut signal_to_rep: HashMap<usize, usize> = HashMap::with_capacity(num_signals);
         let mut uniques: BTreeMap<usize, usize> = BTreeMap::new();
-        for pos in 0..constraints.len(){
-            for k in constraints[pos].c().keys() {
+        for (pos, item) in constraints.iter().enumerate() {
+            for k in item.c().keys() {
                 if signals.can_be_taken(*k) {
-                    match signal_to_ocurrences.get_mut(k){
-                        Some(prev_ocu) =>{
+                    match signal_to_ocurrences.get_mut(k) {
+                        Some(prev_ocu) => {
                             *prev_ocu += 1;
-                        },
+                        }
                         None => {
                             signal_to_ocurrences.insert(*k, 1);
                             signal_to_rep.insert(*k, pos);
@@ -91,18 +91,14 @@ impl SignalsInformation {
         (SignalsInformation{signal_to_ocurrences}, uniques)
     }
 
-    pub fn remove_constraint(&mut self, constraint: &C, signals: &SignalDefinition4){
-        for signal in constraint.c().keys(){
-            if signals.can_be_taken(*signal){
-                match self.signal_to_ocurrences.get_mut(signal){
-                    Some(ocurrences) =>{
-                        *ocurrences -= 1;
-                    },
-                    None => {},
+    pub fn remove_constraint(&mut self, constraint: &C, signals: &SignalDefinition4) {
+        for signal in constraint.c().keys() {
+            if signals.can_be_taken(*signal) {
+                if let Some(ocurrences) = self.signal_to_ocurrences.get_mut(signal) {
+                    *ocurrences -= 1;
                 }
             }
         }
-        
     }
 
 
@@ -408,28 +404,21 @@ fn take_signal_4(signals: &SignalDefinition4, info_ocurrences: &SignalsInformati
     ret
 }
 
+fn normalize_substitutions(substitutions: SHNotNormalized, field: &BigInt) -> SH {
+    let mut coeffs: Vec<BigInt> = Vec::new();
 
-fn normalize_substitutions(substitutions: SHNotNormalized, field: &BigInt) -> SH{
-    let mut coeffs : Vec<BigInt> = Vec::new();
-
-    for (_signal, (coeff, _sub)) in &substitutions{
+    for (coeff, _sub) in substitutions.values() {
         coeffs.push(coeff.clone());
     }
-    
+
     let inverses = modular_arithmetic::multi_inv(&coeffs, field);
-    let mut tree : BTreeMap<usize,S> = BTreeMap::new();
-    let mut i = 0;
-    for (signal, (_coeff, sub)) in substitutions{
+    let mut tree: BTreeMap<usize, S> = BTreeMap::new();
+    for (i, (signal, (_coeff, sub))) in substitutions.into_iter().enumerate() {
         let inv = inverses.get(i).unwrap();
         let arith_sub = A::hashmap_into_arith(sub.to().clone());
-        let mult_by_inverse = A::mul(
-            &arith_sub, 
-            &A::Number {value : inv.clone()}, 
-            field
-        );
-        let new_sub = S::new(signal, mult_by_inverse).unwrap(); 
+        let mult_by_inverse = A::mul(&arith_sub, &A::Number { value: inv.clone() }, field);
+        let new_sub = S::new(signal, mult_by_inverse).unwrap();
         tree.insert(signal, new_sub);
-        i += 1;
     }
     tree
 }

--- a/code_producers/src/c_elements/c_code_generator.rs
+++ b/code_producers/src/c_elements/c_code_generator.rs
@@ -74,7 +74,7 @@ pub fn declare_index_multiple_eq() -> CInstruction {
     format!("uint {}", INDEX_MULTIPLE_EQ)
 }
 pub fn index_multiple_eq() -> CInstruction {
-    format!("{}", INDEX_MULTIPLE_EQ)
+    INDEX_MULTIPLE_EQ.to_string()
 }
 
 pub const FUNCTION_DESTINATION: &str = "destination"; // type PFrElements[]
@@ -92,7 +92,7 @@ pub fn declare_ctx_index() -> CInstruction {
 }
 
 pub fn ctx_index() -> CInstruction {
-    format!("{}", CTX_INDEX)
+    CTX_INDEX.to_string()
 }
 pub fn store_ctx_index(value: CInstruction) -> CInstruction {
     format!("{} = {}", ctx_index(), value)
@@ -135,12 +135,12 @@ pub fn declare_circom_calc_wit() -> CInstruction {
     format!("Circom_CalcWit* {}", CIRCOM_CALC_WIT)
 }
 pub fn circom_calc_wit() -> CInstruction {
-    format!("{}", CIRCOM_CALC_WIT)
+    CIRCOM_CALC_WIT.to_string()
 }
 
 pub const TEMP_INS_2_IO_INFO: &str = "templateInsId2IOSignalInfo";
 pub fn template_ins_2_io_info() -> CInstruction {
-    format!("{}", TEMP_INS_2_IO_INFO)
+    TEMP_INS_2_IO_INFO.to_string()
 }
 
 pub fn template_id_in_component(idx: CInstruction) -> CInstruction {
@@ -154,7 +154,7 @@ pub fn declare_my_signal_start() -> CInstruction {
     )
 }
 pub fn my_signal_start() -> CInstruction {
-    format!("{}", MY_SIGNAL_START)
+    MY_SIGNAL_START.to_string()
 }
 
 pub const MY_TEMPLATE_NAME: &str = "myTemplateName";
@@ -167,11 +167,11 @@ pub fn declare_my_template_name() -> CInstruction {
 pub fn declare_my_template_name_function(name: &String) -> CInstruction {
     format!(
         "std::string {} = \"{}\"",
-        MY_TEMPLATE_NAME, name.to_string()
+        MY_TEMPLATE_NAME, name
     )
 }
 pub fn my_template_name() -> CInstruction {
-    format!("{}", MY_TEMPLATE_NAME)
+    MY_TEMPLATE_NAME.to_string()
 }
 
 
@@ -183,7 +183,7 @@ pub fn declare_my_component_name() -> CInstruction {
     )
 }
 pub fn my_component_name() -> CInstruction {
-    format!("{}", MY_COMPONENT_NAME)
+    MY_COMPONENT_NAME.to_string()
 }
 
 pub const MY_FATHER: &str = "myFather";
@@ -194,7 +194,7 @@ pub fn declare_my_father() -> CInstruction {
     )
 }
 pub fn my_father() -> CInstruction {
-    format!("{}", MY_FATHER)
+    MY_FATHER.to_string()
 }
 
 pub const MY_ID: &str = "myId";
@@ -205,17 +205,17 @@ pub fn declare_my_id() -> CInstruction {
     )
 }
 pub fn my_id() -> CInstruction {
-    format!("{}", MY_ID)
+    MY_ID.to_string()
 }
 
 pub const FUNCTION_TABLE: &str = "_functionTable";
 pub fn function_table() -> CInstruction {
-    format!("{}", FUNCTION_TABLE)
+    FUNCTION_TABLE.to_string()
 }
 
 pub const FUNCTION_TABLE_PARALLEL: &str = "_functionTableParallel";
 pub fn function_table_parallel() -> CInstruction {
-    format!("{}", FUNCTION_TABLE_PARALLEL)
+    FUNCTION_TABLE_PARALLEL.to_string()
 }
 
 pub const SIGNAL_VALUES: &str = "signalValues";
@@ -292,7 +292,7 @@ pub fn declare_my_subcomponents() -> CInstruction {
     )
 }
 pub fn my_subcomponents() -> CInstruction {
-    format!("{}", MY_SUBCOMPONENTS)
+    MY_SUBCOMPONENTS.to_string()
 }
 
 pub const MY_SUBCOMPONENTS_PARALLEL: &str = "mySubcomponentsParallel";
@@ -303,7 +303,7 @@ pub fn declare_my_subcomponents_parallel() -> CInstruction {
     )
 }
 pub fn my_subcomponents_parallel() -> CInstruction {
-    format!("{}", MY_SUBCOMPONENTS_PARALLEL)
+    MY_SUBCOMPONENTS_PARALLEL.to_string()
 }
 
 pub const CIRCUIT_CONSTANTS: &str = "circuitConstants";
@@ -322,7 +322,7 @@ pub fn declare_free_position_in_component_memory() -> CInstruction {
     format!("u32 {} = {}->{}", FREE_IN_COMPONENT_MEM, CIRCOM_CALC_WIT, FREE_IN_COMPONENT_MEM)
 }
 pub fn free_position_in_component_memory() -> CInstruction {
-    format!("{}", FREE_IN_COMPONENT_MEM)
+    FREE_IN_COMPONENT_MEM.to_string()
 }
 pub fn store_free_position_in_component_memory(value: String) -> CInstruction {
     format!("{} = {}", FREE_IN_COMPONENT_MEM, value)
@@ -336,7 +336,7 @@ pub fn declare_list_of_template_messages_use() -> CInstruction {
     )
 }
 pub fn list_of_template_messages_use() -> CInstruction {
-    format!("{}", LIST_OF_TEMPLATE_MESSAGES)
+    LIST_OF_TEMPLATE_MESSAGES.to_string()
 }
 
 pub fn build_callable(header: String, params: Vec<String>, body: Vec<String>) -> String {
@@ -521,10 +521,10 @@ pub fn generate_dat_constant_list(producer: &CProducer, constant_list: &Vec<Stri
         let p = producer.get_prime().parse::<BigInt>().unwrap();
         let b = ((p.bits() + 63) / 64) * 64;
         let mut r = BigInt::from(1);
-        r = r << b;
-        n = n % BigInt::clone(&p);
-        n = n + BigInt::clone(&p);
-        n = n % BigInt::clone(&p);
+        r <<= b;
+        n %= BigInt::clone(&p);
+        n += BigInt::clone(&p);
+        n %= BigInt::clone(&p);
         let hp = BigInt::clone(&p) / 2;
         let mut nn;
         if BigInt::clone(&n) > hp {
@@ -547,7 +547,7 @@ pub fn generate_dat_constant_list(producer: &CProducer, constant_list: &Vec<Stri
                 constant_list_data.push(0);
             }
             //short Montgomery
-            let sm = 0x40000000 as u32;
+            let sm = 0x40000000_u32;
             let mut v: Vec<u8> = sm.to_be_bytes().to_vec();
             v.reverse();
             constant_list_data.append(&mut v);
@@ -556,7 +556,7 @@ pub fn generate_dat_constant_list(producer: &CProducer, constant_list: &Vec<Stri
             for _i in 0..4 {
                 constant_list_data.push(0);
             }
-            let lm = 0xC0000000 as u32;
+            let lm = 0xC0000000_u32;
             let mut v: Vec<u8> = lm.to_be_bytes().to_vec();
             v.reverse();
             constant_list_data.append(&mut v);
@@ -602,7 +602,7 @@ pub fn generate_dat_io_signals_info(
             v.reverse();
             io_signals_info.append(&mut v);
             let n32: u32;
-            if s.lengths.len() > 0 {
+            if !s.lengths.is_empty() {
                 n32 = (s.lengths.len() - 1) as u32;
             } else {
                 n32 = 0;
@@ -653,7 +653,7 @@ pub fn generate_dat_file(dat_file: &mut dyn Write, producer: &CProducer) -> std:
     //dfile.flush()?;
 
     let aux = producer.get_main_input_list();
-    let map = generate_hash_map(&aux);
+    let map = generate_hash_map(aux);
     let hashmap = generate_dat_from_hash_map(&map); //bytes u64 --> u64
                                                     //let hml = 256 as u32;
                                                     //dfile.write_all(&hml.to_be_bytes())?;
@@ -669,7 +669,7 @@ pub fn generate_dat_file(dat_file: &mut dyn Write, producer: &CProducer) -> std:
     //dat_file.flush()?;
     //let ioml = producer.get_io_map().len() as u64;
     //dfile.write_all(&ioml.to_be_bytes())?;
-    let iomap = generate_dat_io_signals_info(&producer, producer.get_io_map());
+    let iomap = generate_dat_io_signals_info(producer, producer.get_io_map());
     dat_file.write_all(&iomap)?;
     /*
         let ml = producer.get_message_list();
@@ -689,27 +689,27 @@ pub fn generate_dat_file(dat_file: &mut dyn Write, producer: &CProducer) -> std:
 pub fn generate_function_list(_producer: &CProducer, list: &TemplateListParallel) -> (String, String) {
     let mut func_list= "".to_string();
     let mut func_list_parallel= "".to_string();
-    if list.len() > 0 {
+    if !list.is_empty() {
         if list[0].is_parallel{
             func_list_parallel.push_str(&format!("\n{}_run_parallel",list[0].name));
         }else{
-            func_list_parallel.push_str(&format!("\nNULL"));
+            func_list_parallel.push_str("\nNULL");
         }
         if list[0].is_not_parallel{
             func_list.push_str(&format!("\n{}_run",list[0].name));
         }else{
-            func_list.push_str(&format!("\nNULL"));
+            func_list.push_str("\nNULL");
         }
 	    for i in 1..list.len() {
             if list[i].is_parallel{
                 func_list_parallel.push_str(&format!(",\n{}_run_parallel",list[i].name));
             }else{
-                func_list_parallel.push_str(&format!(",\nNULL"));
+                func_list_parallel.push_str(",\nNULL");
             }
             if list[i].is_not_parallel{
                 func_list.push_str(&format!(",\n{}_run",list[i].name));
             }else{
-                func_list.push_str(&format!(",\nNULL"));
+                func_list.push_str(",\nNULL");
             }
 	    }
     }
@@ -722,7 +722,7 @@ pub fn generate_message_list_def(_producer: &CProducer, message_list: &MessageLi
     let start = format!("std::string {}1 [] = {{\n", list_of_messages);
     // let start = format!("{}1 [] = {{\n",producer.get_list_of_messages_name());
     instructions.push(start);
-    if message_list.len() > 0 {
+    if !message_list.is_empty() {
         instructions.push(format!("\"{}\"", message_list[0]));
         for i in 1..message_list.len() {
             instructions.push(format!(",\n\"{}\"", message_list[i]));
@@ -996,7 +996,7 @@ mod tests {
     use std::path::Path;
     //    use std::fs::File;
     use super::*;
-    const LOCATION: &'static str = "../target/code_generator_test";
+    const LOCATION: &str = "../target/code_generator_test";
 
     fn create_producer() -> CProducer {
         CProducer::default()

--- a/code_producers/src/wasm_elements/mod.rs
+++ b/code_producers/src/wasm_elements/mod.rs
@@ -236,7 +236,7 @@ impl WASMProducer {
         for (_c, v) in &self.io_map {
             for s in v {
                 // since we take offset and all lengths but last one
-                if s.lengths.len() == 0 {
+                if s.lengths.is_empty() {
                     n += 1;
                 } else {
                     n += s.lengths.len();

--- a/code_producers/src/wasm_elements/mod.rs
+++ b/code_producers/src/wasm_elements/mod.rs
@@ -226,14 +226,14 @@ impl WASMProducer {
     }
     pub fn get_number_of_io_signals(&self) -> usize {
         let mut n = 0;
-        for (_c, v) in &self.io_map {
+        for v in self.io_map.values() {
             n += v.len();
         }
         n
     }
     pub fn get_io_signals_info_size(&self) -> usize {
         let mut n = 0;
-        for (_c, v) in &self.io_map {
+        for v in self.io_map.values() {
             for s in v {
                 // since we take offset and all lengths but last one
                 if s.lengths.is_empty() {

--- a/compiler/src/circuit_design/build.rs
+++ b/compiler/src/circuit_design/build.rs
@@ -62,10 +62,8 @@ fn build_template_instances(
             match component_to_parallel.get_mut(&trigger.component_name){
                 Some(parallel_info) => {
                     parallel_info.positions_to_parallel.insert(trigger.indexed_with.clone(), trigger.is_parallel);
-                    if parallel_info.uniform_parallel_value.is_some(){
-                        if parallel_info.uniform_parallel_value.unwrap() != trigger.is_parallel{
-                            parallel_info.uniform_parallel_value = None;
-                        }
+                    if parallel_info.uniform_parallel_value.is_some() && parallel_info.uniform_parallel_value.unwrap() != trigger.is_parallel {
+                        parallel_info.uniform_parallel_value = None;
                     }
                 },
                 None => {
@@ -96,7 +94,7 @@ fn build_template_instances(
             fresh_cmp_id: cmp_id,
             components: template.components,
             template_database: &c_info.template_database,
-            string_table : string_table,
+            string_table,
             signals_to_tags: template.signals_to_tags,
         };
         let mut template_info = TemplateCodeInfo {
@@ -160,7 +158,7 @@ fn build_function_instances(
             cmp_to_type: HashMap::with_capacity(0),
             component_to_parallel: HashMap::with_capacity(0),
             template_database: &c_info.template_database,
-            string_table : string_table,
+            string_table,
             signals_to_tags: BTreeMap::new(),
         };
         let mut function_info = FunctionCodeInfo {
@@ -345,7 +343,7 @@ fn write_main_inputs_log(vcp: &VCP) {
 
 fn get_number_version(version: &str) -> (usize, usize, usize) {
     use std::str::FromStr;
-    let version_splitted: Vec<&str> = version.split(".").collect();
+    let version_splitted: Vec<&str> = version.split('.').collect();
     (
         usize::from_str(version_splitted[0]).unwrap(),
         usize::from_str(version_splitted[1]).unwrap(),

--- a/compiler/src/circuit_design/circuit.rs
+++ b/compiler/src/circuit_design/circuit.rs
@@ -12,6 +12,7 @@ pub struct CompilationFlags {
     pub wat_flag:bool,
 }
 
+#[derive(Default)]
 pub struct Circuit {
     pub wasm_producer: WASMProducer,
     pub c_producer: CProducer,
@@ -19,16 +20,7 @@ pub struct Circuit {
     pub functions: Vec<FunctionCode>,
 }
 
-impl Default for Circuit {
-    fn default() -> Self {
-        Circuit {
-            c_producer: CProducer::default(),
-            wasm_producer: WASMProducer::default(),
-            templates: Vec::new(),
-            functions: Vec::new(),
-        }
-    }
-}
+
 
 impl WriteWasm for Circuit {
     fn produce_wasm(&self, producer: &WASMProducer) -> Vec<String> {
@@ -37,7 +29,7 @@ impl WriteWasm for Circuit {
         code.push("(module".to_string());
         let mut code_aux = generate_imports_list();
         code.append(&mut code_aux);
-        code_aux = generate_memory_def_list(&producer);
+        code_aux = generate_memory_def_list(producer);
         code.append(&mut code_aux);
 
         code_aux = fr_types(&producer.prime_str);
@@ -51,61 +43,61 @@ impl WriteWasm for Circuit {
         code_aux = fr_code(&producer.prime_str);
         code.append(&mut code_aux);
 
-        code_aux = desp_io_subcomponent_generator(&producer);
+        code_aux = desp_io_subcomponent_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = get_version_generator(&producer);
+        code_aux = get_version_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = get_shared_rw_memory_start_generator(&producer);
+        code_aux = get_shared_rw_memory_start_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = read_shared_rw_memory_generator(&producer);
+        code_aux = read_shared_rw_memory_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = write_shared_rw_memory_generator(&producer);
+        code_aux = write_shared_rw_memory_generator(producer);
         code.append(&mut code_aux);
 
         code_aux = reserve_stack_fr_function_generator();
         code.append(&mut code_aux);
 
-        code_aux = init_generator(&producer);
+        code_aux = init_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = set_input_signal_generator(&producer);
+        code_aux = set_input_signal_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = get_input_signal_size_generator(&producer);
+        code_aux = get_input_signal_size_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = get_raw_prime_generator(&producer);
+        code_aux = get_raw_prime_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = get_field_num_len32_generator(&producer);
+        code_aux = get_field_num_len32_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = get_input_size_generator(&producer);
+        code_aux = get_input_size_generator(producer);
         code.append(&mut code_aux);	
 
-        code_aux = get_witness_size_generator(&producer);
+        code_aux = get_witness_size_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = get_witness_generator(&producer);
+        code_aux = get_witness_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = copy_32_in_shared_rw_memory_generator(&producer);
+        code_aux = copy_32_in_shared_rw_memory_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = copy_fr_in_shared_rw_memory_generator(&producer);
+        code_aux = copy_fr_in_shared_rw_memory_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = get_message_char_generator(&producer);
+        code_aux = get_message_char_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = build_buffer_message_generator(&producer);
+        code_aux = build_buffer_message_generator(producer);
         code.append(&mut code_aux);
 
-        code_aux = build_log_message_generator(&producer);
+        code_aux = build_log_message_generator(producer);
         code.append(&mut code_aux);
 
         // Actual code from the program
@@ -118,13 +110,13 @@ impl WriteWasm for Circuit {
             code.append(&mut t.produce_wasm(producer));
         }
 
-        code_aux = generate_table_of_template_runs(&producer);
+        code_aux = generate_table_of_template_runs(producer);
         code.append(&mut code_aux);
 
         code_aux = fr_data(&producer.prime_str);
         code.append(&mut code_aux);
 
-        code_aux = generate_data_list(&producer);
+        code_aux = generate_data_list(producer);
         code.append(&mut code_aux);
 
         code.push(")".to_string());
@@ -142,7 +134,7 @@ impl WriteWasm for Circuit {
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = generate_memory_def_list(&producer);
+        code_aux = generate_memory_def_list(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
@@ -167,27 +159,27 @@ impl WriteWasm for Circuit {
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = desp_io_subcomponent_generator(&producer);
+        code_aux = desp_io_subcomponent_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = get_version_generator(&producer);
+        code_aux = get_version_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = get_shared_rw_memory_start_generator(&producer);
+        code_aux = get_shared_rw_memory_start_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = read_shared_rw_memory_generator(&producer);
+        code_aux = read_shared_rw_memory_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = write_shared_rw_memory_generator(&producer);
+        code_aux = write_shared_rw_memory_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
@@ -197,67 +189,67 @@ impl WriteWasm for Circuit {
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = init_generator(&producer);
+        code_aux = init_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = set_input_signal_generator(&producer);
+        code_aux = set_input_signal_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = get_input_signal_size_generator(&producer);
+        code_aux = get_input_signal_size_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = get_raw_prime_generator(&producer);
+        code_aux = get_raw_prime_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = get_field_num_len32_generator(&producer);
+        code_aux = get_field_num_len32_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = get_input_size_generator(&producer);
+        code_aux = get_input_size_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 	
-        code_aux = get_witness_size_generator(&producer);
+        code_aux = get_witness_size_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = get_witness_generator(&producer);
+        code_aux = get_witness_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = copy_32_in_shared_rw_memory_generator(&producer);
+        code_aux = copy_32_in_shared_rw_memory_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = copy_fr_in_shared_rw_memory_generator(&producer);
+        code_aux = copy_fr_in_shared_rw_memory_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = get_message_char_generator(&producer);
+        code_aux = get_message_char_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = build_buffer_message_generator(&producer);
+        code_aux = build_buffer_message_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = build_log_message_generator(&producer);
+        code_aux = build_log_message_generator(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
@@ -274,7 +266,7 @@ impl WriteWasm for Circuit {
             //writer.flush().map_err(|_| {})?;
         }
 
-        code_aux = generate_table_of_template_runs(&producer);
+        code_aux = generate_table_of_template_runs(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
@@ -284,7 +276,7 @@ impl WriteWasm for Circuit {
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;
 
-        code_aux = generate_data_list(&producer);
+        code_aux = generate_data_list(producer);
         code = merge_code(code_aux);
         writer.write_all(code.as_bytes()).map_err(|_| {})?;
         //writer.flush().map_err(|_| {})?;

--- a/compiler/src/circuit_design/circuit.rs
+++ b/compiler/src/circuit_design/circuit.rs
@@ -289,13 +289,14 @@ impl WriteWasm for Circuit {
 impl WriteC for Circuit {
     fn produce_c(&self, producer: &CProducer, _parallel: Option<bool>) -> (Vec<String>, String) {
         use c_code_generator::*;
-        let mut code = vec![];
-        // Prologue
-        code.push("#include <stdio.h>".to_string());
-        code.push("#include <iostream>".to_string());
-        code.push("#include <assert.h>".to_string());
-        code.push("#include \"circom.hpp\"".to_string());
-        code.push("#include \"calcwit.hpp\"".to_string());
+        let mut code = vec![
+            // Prologue
+            "#include <stdio.h>".to_string(),
+            "#include <iostream>".to_string(),
+            "#include <assert.h>".to_string(),
+            "#include \"circom.hpp\"".to_string(),
+            "#include \"calcwit.hpp\"".to_string(),
+        ];
 
         let mut template_headers = collect_template_headers(producer.get_template_instance_list());
         let function_headers: Vec<_> = self.functions
@@ -391,11 +392,12 @@ impl WriteC for Circuit {
         } else{
             producer.main_header.clone() + "_run"
         };
-        let mut run_args = vec![];
-        // run_args.push(CTX_INDEX.to_string());
-	run_args.push("0".to_string());
-        run_args.push(CIRCOM_CALC_WIT.to_string());
-        let run_call = format!("{};", build_call(main_template_run, run_args.clone()));
+        let run_args = vec![
+            // CTX_INDEX.to_string(),
+            "0".to_string(),
+            CIRCOM_CALC_WIT.to_string(),
+        ];
+        let run_call = format!("{};", build_call(main_template_run, run_args));
 
         let main_run_body = vec![ctx_index, run_call];
         code.push(build_callable(run_circuit, run_circuit_args, main_run_body));
@@ -522,11 +524,12 @@ impl WriteC for Circuit {
         } else{
             producer.main_header.clone() + "_run"
         };
-        let mut run_args = vec![];
-        // run_args.push(CTX_INDEX.to_string());
-	run_args.push("0".to_string());
-        run_args.push(CIRCOM_CALC_WIT.to_string());
-        let run_call = format!("{};", build_call(main_template_run, run_args.clone()));
+        let run_args = vec![
+            // CTX_INDEX.to_string(),
+            "0".to_string(),
+            CIRCOM_CALC_WIT.to_string(),
+        ];
+        let run_call = format!("{};", build_call(main_template_run, run_args));
 
         let main_run_body = vec![ctx_index, run_call];
 	code_write = build_callable(run_circuit, run_circuit_args, main_run_body) + "\n";
@@ -566,6 +569,7 @@ impl Circuit {
     pub fn produce_ir_string_for_function(&self, id: ID) -> String {
         self.functions[id].to_string()
     }
+    #[allow(clippy::result_unit_err)]
     pub fn produce_c<W: Write>(&self, c_folder: &str, run_name: &str, c_circuit: &mut W, c_dat: &mut W) -> Result<(), ()> {
 	use std::path::Path;
 	let c_folder_path = Path::new(c_folder).to_path_buf();
@@ -580,6 +584,7 @@ impl Circuit {
         c_code_generator::generate_dat_file(c_dat, &self.c_producer).map_err(|_err| {})?;
         self.write_c(c_circuit, &self.c_producer)
     }
+    #[allow(clippy::result_unit_err)]
     pub fn produce_wasm<W: Write>(&self, js_folder: &str, _wasm_name: &str, writer: &mut W) -> Result<(), ()> {
 	use std::path::Path;
 	let js_folder_path = Path::new(js_folder).to_path_buf();

--- a/compiler/src/circuit_design/template.rs
+++ b/compiler/src/circuit_design/template.rs
@@ -296,13 +296,13 @@ impl TemplateCodeInfo {
         }
 	// parallelism (join at the end of the function)
 	if self.number_of_components > 0 && self.has_parallel_sub_cmp {
-            run_body.push(format!("{{"));
+            run_body.push("{".to_string());
 	    run_body.push(format!("for (uint i = 0; i < {}; i++) {{",&self.number_of_components.to_string()));
-	    run_body.push(format!("if (ctx->componentMemory[ctx_index].sbct[i].joinable()) {{"));
-	    run_body.push(format!("ctx->componentMemory[ctx_index].sbct[i].join();"));
-	    run_body.push(format!("}}"));
-	    run_body.push(format!("}}"));
-	    run_body.push(format!("}}"));
+	    run_body.push("if (ctx->componentMemory[ctx_index].sbct[i].joinable()) {".to_string());
+	    run_body.push("ctx->componentMemory[ctx_index].sbct[i].join();".to_string());
+	    run_body.push("}".to_string());
+	    run_body.push("}".to_string());
+	    run_body.push("}".to_string());
 	}
 	if parallel {
 	    // parallelism
@@ -312,13 +312,13 @@ impl TemplateCodeInfo {
 		run_body.push(format!("{}->componentMemory[{}].outputIsSet[i]=true;",CIRCOM_CALC_WIT,CTX_INDEX));
 	    run_body.push(format!("{}->componentMemory[{}].mutexes[i].unlock();",CIRCOM_CALC_WIT,CTX_INDEX));
 	    run_body.push(format!("{}->componentMemory[{}].cvs[i].notify_all();",CIRCOM_CALC_WIT,CTX_INDEX));	    
-        run_body.push(format!("}}"));
+        run_body.push("}".to_string());
         //parallelism
-        run_body.push(format!("ctx->numThreadMutex.lock();"));
-	    run_body.push(format!("ctx->numThread--;"));
+        run_body.push("ctx->numThreadMutex.lock();".to_string());
+	    run_body.push("ctx->numThread--;".to_string());
         //run_body.push(format!("printf(\"%i \\n\", ctx->numThread);"));
-        run_body.push(format!("ctx->numThreadMutex.unlock();"));
-	    run_body.push(format!("ctx->ntcvs.notify_one();"));
+        run_body.push("ctx->numThreadMutex.unlock();".to_string());
+	    run_body.push("ctx->ntcvs.notify_one();".to_string());
 	}
 
         // to release the memory of its subcomponents
@@ -334,7 +334,7 @@ impl TemplateCodeInfo {
                 vec![CIRCOM_CALC_WIT.to_string(), "index_subc".to_string()]
             )));
         
-        run_body.push(format!("}}"));
+        run_body.push("}".to_string());
         let run_fun = build_callable(run_header, run_params, run_body);
         vec![create_fun, run_fun]
     }

--- a/compiler/src/circuit_design/template.rs
+++ b/compiler/src/circuit_design/template.rs
@@ -16,7 +16,7 @@ pub struct TemplateCodeInfo {
     pub is_not_parallel_component: bool,
     pub has_parallel_sub_cmp: bool,
     pub number_of_inputs: usize,
-    pub number_of_outputs: usize, 
+    pub number_of_outputs: usize,
     pub number_of_intermediates: usize, // Not used now
     pub body: InstructionList,
     pub var_stack_depth: usize,
@@ -24,6 +24,7 @@ pub struct TemplateCodeInfo {
     pub signal_stack_depth: usize, // Not used now
     pub number_of_components: usize,
 }
+
 impl ToString for TemplateCodeInfo {
     fn to_string(&self) -> String {
         let mut body = "".to_string();
@@ -33,13 +34,13 @@ impl ToString for TemplateCodeInfo {
         format!("TEMPLATE({})(\n{})", self.header, body)
     }
 }
+
 impl WriteWasm for TemplateCodeInfo {
     fn produce_wasm(&self, producer: &WASMProducer) -> Vec<String> {
         use code_producers::wasm_elements::wasm_code_generator::*;
         // create function code
         let mut instructions = vec![];
-        let funcdef1 = format!("(func ${}_create (type $_t_i32ri32)", self.header); //return offset
-        instructions.push(funcdef1);
+        instructions.push(format!("(func ${}_create (type $_t_i32ri32)", self.header)); //return offset
         instructions.push(format!(" (param {} i32)", producer.get_signal_offset_tag()));
         instructions.push("(result i32)".to_string());
         instructions.push(format!(" (local {} i32)", producer.get_offset_tag())); //here is a local var to be returned
@@ -64,9 +65,10 @@ impl WriteWasm for TemplateCodeInfo {
         //reserve memory for component
         instructions.push(set_constant(&producer.get_component_free_pos().to_string()));
         instructions.push(get_local(producer.get_offset_tag()));
-        let nbytes_component =
-            producer.get_sub_component_start_in_component() + self.number_of_components * 4;
-        instructions.push(set_constant(&nbytes_component.to_string()));
+        instructions.push(set_constant(
+            &(producer.get_sub_component_start_in_component() + self.number_of_components * 4)
+                .to_string(),
+        ));
         instructions.push(add32());
         instructions.push(store32(None));
         //add the position of the component in the tree as result
@@ -74,11 +76,9 @@ impl WriteWasm for TemplateCodeInfo {
         instructions.push(")".to_string());
 
         // run function code
-
-        let funcdef2 = format!("(func ${}_run (type $_t_i32ri32)", self.header);
-        instructions.push(funcdef2);
+        instructions.push(format!("(func ${}_run (type $_t_i32ri32)", self.header));
         instructions.push(format!(" (param {} i32)", producer.get_offset_tag()));
-	instructions.push("(result i32)".to_string()); //state 0 = OK; > 0 error
+        instructions.push("(result i32)".to_string()); //state 0 = OK; > 0 error
         instructions.push(format!(" (local {} i32)", producer.get_cstack_tag()));
         instructions.push(format!(" (local {} i32)", producer.get_signal_start_tag()));
         instructions.push(format!(" (local {} i32)", producer.get_sub_cmp_tag()));
@@ -123,7 +123,7 @@ impl WriteWasm for TemplateCodeInfo {
         instructions.append(&mut reserve_stack_fr_code);
         if producer.needs_comments() {
             instructions.push(";; start of the template code".to_string());
-	}
+        }
         //set signalstart local
         instructions.push(get_local(producer.get_offset_tag()));
         instructions
@@ -131,8 +131,8 @@ impl WriteWasm for TemplateCodeInfo {
         instructions.push(add32());
         instructions.push(load32(None));
         instructions.push(set_local(producer.get_signal_start_tag()));
-        //generate code
 
+        //generate code
         for t in &self.body {
             let mut instructions_body = t.produce_wasm(producer);
             instructions.append(&mut instructions_body);
@@ -141,7 +141,7 @@ impl WriteWasm for TemplateCodeInfo {
         //free stack
         let mut free_stack_code = free_stack(producer);
         instructions.append(&mut free_stack_code);
-        instructions.push(set_constant("0"));	
+        instructions.push(set_constant("0"));
         instructions.push(")".to_string());
         instructions
     }
@@ -150,75 +150,78 @@ impl WriteWasm for TemplateCodeInfo {
 impl WriteC for TemplateCodeInfo {
     fn produce_c(&self, producer: &CProducer, _parallel: Option<bool>) -> (Vec<String>, String) {
         let mut produced_c = Vec::new();
-        if self.is_parallel || self.is_parallel_component{
+        if self.is_parallel || self.is_parallel_component {
             produced_c.append(&mut self.produce_c_parallel_case(producer, true));
         }
-        if !self.is_parallel && self.is_not_parallel_component{
+        if !self.is_parallel && self.is_not_parallel_component {
             produced_c.append(&mut self.produce_c_parallel_case(producer, false));
-        } 
+        }
         (produced_c, "".to_string())
     }
 }
-
 
 impl TemplateCodeInfo {
     fn produce_c_parallel_case(&self, producer: &CProducer, parallel: bool) -> Vec<String> {
         use c_code_generator::*;
 
-        let create_header = if parallel {format!("void {}_create_parallel", self.header)}
-            else{format!("void {}_create", self.header)} ;
-        let mut create_params = vec![];
-        create_params.push(declare_signal_offset());
-        create_params.push(declare_component_offset());
-        create_params.push(declare_circom_calc_wit());
-        create_params.push(declare_component_name());
-        create_params.push(declare_component_father());
-        let mut create_body = vec![];
+        let create_header = if parallel {
+            format!("void {}_create_parallel", self.header)
+        } else {
+            format!("void {}_create", self.header)
+        };
+        let create_params = vec![
+            declare_signal_offset(),
+            declare_component_offset(),
+            declare_circom_calc_wit(),
+            declare_component_name(),
+            declare_component_father(),
+        ];
 
+        let mut create_body = vec![];
         create_body.push(format!(
             "{}->componentMemory[{}].templateId = {};",
             CIRCOM_CALC_WIT,
-	        component_offset(),
+            component_offset(),
             &self.id.to_string()
         ));
         create_body.push(format!(
             "{}->componentMemory[{}].templateName = \"{}\";",
             CIRCOM_CALC_WIT,
-	        component_offset(),
+            component_offset(),
             &self.name.to_string()
         ));
         create_body.push(format!(
             "{}->componentMemory[{}].signalStart = {};",
             CIRCOM_CALC_WIT,
-	        component_offset(),
-	        SIGNAL_OFFSET
+            component_offset(),
+            SIGNAL_OFFSET
         ));
         create_body.push(format!(
             "{}->componentMemory[{}].inputCounter = {};",
             CIRCOM_CALC_WIT,
-	        component_offset(),
+            component_offset(),
             &self.number_of_inputs.to_string()
         ));
         create_body.push(format!(
             "{}->componentMemory[{}].componentName = {};",
             CIRCOM_CALC_WIT,
-	        component_offset(),
+            component_offset(),
             COMPONENT_NAME
         ));
         create_body.push(format!(
             "{}->componentMemory[{}].idFather = {};",
             CIRCOM_CALC_WIT,
-	        component_offset(),
+            component_offset(),
             COMPONENT_FATHER
         ));
-        if self.number_of_components > 0{
+        if self.number_of_components > 0 {
             create_body.push(format!(
                 "{}->componentMemory[{}].subcomponents = new uint[{}]{{0}};",
                 CIRCOM_CALC_WIT,
                 component_offset(),
                 &self.number_of_components.to_string()
             ));
-        } else{
+        } else {
             create_body.push(format!(
                 "{}->componentMemory[{}].subcomponents = new uint[{}];",
                 CIRCOM_CALC_WIT,
@@ -226,114 +229,140 @@ impl TemplateCodeInfo {
                 &self.number_of_components.to_string()
             ));
         }
-	if self.has_parallel_sub_cmp {
+        if self.has_parallel_sub_cmp {
             create_body.push(format!(
-		"{}->componentMemory[{}].sbct = new std::thread[{}];",
-		CIRCOM_CALC_WIT,
-		component_offset(),
-		&self.number_of_components.to_string()
+                "{}->componentMemory[{}].sbct = new std::thread[{}];",
+                CIRCOM_CALC_WIT,
+                component_offset(),
+                &self.number_of_components.to_string()
             ));
 
-        create_body.push(format!(
-            "{}->componentMemory[{}].subcomponentsParallel = new bool[{}];",
-            CIRCOM_CALC_WIT,
-            component_offset(),
-            &self.number_of_components.to_string()
-        ));
-	}
-	if parallel {
             create_body.push(format!(
-		"{}->componentMemory[{}].outputIsSet = new bool[{}]();",
-		CIRCOM_CALC_WIT,
-		component_offset(),
-		&self.number_of_outputs.to_string()
+                "{}->componentMemory[{}].subcomponentsParallel = new bool[{}];",
+                CIRCOM_CALC_WIT,
+                component_offset(),
+                &self.number_of_components.to_string()
+            ));
+        }
+        if parallel {
+            create_body.push(format!(
+                "{}->componentMemory[{}].outputIsSet = new bool[{}]();",
+                CIRCOM_CALC_WIT,
+                component_offset(),
+                &self.number_of_outputs.to_string()
             ));
             create_body.push(format!(
-		"{}->componentMemory[{}].mutexes = new std::mutex[{}];",
-		CIRCOM_CALC_WIT,
-		component_offset(),
-		&self.number_of_outputs.to_string()
+                "{}->componentMemory[{}].mutexes = new std::mutex[{}];",
+                CIRCOM_CALC_WIT,
+                component_offset(),
+                &self.number_of_outputs.to_string()
             ));
             create_body.push(format!(
-		"{}->componentMemory[{}].cvs = new std::condition_variable[{}];",
-		CIRCOM_CALC_WIT,
-		component_offset(),
-		&self.number_of_outputs.to_string()
+                "{}->componentMemory[{}].cvs = new std::condition_variable[{}];",
+                CIRCOM_CALC_WIT,
+                component_offset(),
+                &self.number_of_outputs.to_string()
             ));
-	}
-	// if has no inputs should be runned
-	if self.number_of_inputs == 0 {
-	    let cmp_call_name = format!("{}_run", self.header);
-	    let cmp_call_arguments = vec![component_offset(), CIRCOM_CALC_WIT.to_string()]; 
-	    create_body.push(format!("{};",build_call(cmp_call_name, cmp_call_arguments)));
+        }
+        // if has no inputs should be runned
+        if self.number_of_inputs == 0 {
+            let cmp_call_name = format!("{}_run", self.header);
+            let cmp_call_arguments = vec![component_offset(), CIRCOM_CALC_WIT.to_string()];
+            create_body.push(format!("{};", build_call(cmp_call_name, cmp_call_arguments)));
         }
         let create_fun = build_callable(create_header, create_params, create_body);
 
-        let run_header = if parallel {format!("void {}_run_parallel", self.header)}
-            else{format!("void {}_run", self.header)} ;
-        let mut run_params = vec![];
-        run_params.push(declare_ctx_index());
-        run_params.push(declare_circom_calc_wit());
-        let mut run_body = vec![];
-        run_body.push(format!("{};", declare_signal_values()));
-        run_body.push(format!("{};", declare_my_signal_start()));
-        run_body.push(format!("{};", declare_my_template_name()));
-        run_body.push(format!("{};", declare_my_component_name()));
-        run_body.push(format!("{};", declare_my_father()));
-        run_body.push(format!("{};", declare_my_id()));
-        run_body.push(format!("{};", declare_my_subcomponents()));
-        run_body.push(format!("{};", declare_my_subcomponents_parallel()));
-        run_body.push(format!("{};", declare_circuit_constants()));
-        run_body.push(format!("{};", declare_list_of_template_messages_use()));
-        run_body.push(format!("{};", declare_expaux(self.expression_stack_depth)));
-        run_body.push(format!("{};", declare_lvar(self.var_stack_depth)));
-        run_body.push(format!("{};", declare_sub_component_aux()));
-        run_body.push(format!("{};", declare_index_multiple_eq()));
-        
+        let run_header = if parallel {
+            format!("void {}_run_parallel", self.header)
+        } else {
+            format!("void {}_run", self.header)
+        };
+        let run_params = vec![declare_ctx_index(), declare_circom_calc_wit()];
+
+        let mut run_body = vec![
+            format!("{};", declare_signal_values()),
+            format!("{};", declare_my_signal_start()),
+            format!("{};", declare_my_template_name()),
+            format!("{};", declare_my_component_name()),
+            format!("{};", declare_my_father()),
+            format!("{};", declare_my_id()),
+            format!("{};", declare_my_subcomponents()),
+            format!("{};", declare_my_subcomponents_parallel()),
+            format!("{};", declare_circuit_constants()),
+            format!("{};", declare_list_of_template_messages_use()),
+            format!("{};", declare_expaux(self.expression_stack_depth)),
+            format!("{};", declare_lvar(self.var_stack_depth)),
+            format!("{};", declare_sub_component_aux()),
+            format!("{};", declare_index_multiple_eq()),
+        ];
+
         for t in &self.body {
             let (mut instructions_body, _) = t.produce_c(producer, Some(parallel));
             run_body.append(&mut instructions_body);
         }
-	// parallelism (join at the end of the function)
-	if self.number_of_components > 0 && self.has_parallel_sub_cmp {
+        // parallelism (join at the end of the function)
+        if self.number_of_components > 0 && self.has_parallel_sub_cmp {
             run_body.push("{".to_string());
-	    run_body.push(format!("for (uint i = 0; i < {}; i++) {{",&self.number_of_components.to_string()));
-	    run_body.push("if (ctx->componentMemory[ctx_index].sbct[i].joinable()) {".to_string());
-	    run_body.push("ctx->componentMemory[ctx_index].sbct[i].join();".to_string());
-	    run_body.push("}".to_string());
-	    run_body.push("}".to_string());
-	    run_body.push("}".to_string());
-	}
-	if parallel {
-	    // parallelism
-        // set to true all outputs
-        run_body.push(format!("for (uint i = 0; i < {}; i++) {{", &self.number_of_outputs.to_string()));
-        run_body.push(format!("{}->componentMemory[{}].mutexes[i].lock();",CIRCOM_CALC_WIT,CTX_INDEX));
-		run_body.push(format!("{}->componentMemory[{}].outputIsSet[i]=true;",CIRCOM_CALC_WIT,CTX_INDEX));
-	    run_body.push(format!("{}->componentMemory[{}].mutexes[i].unlock();",CIRCOM_CALC_WIT,CTX_INDEX));
-	    run_body.push(format!("{}->componentMemory[{}].cvs[i].notify_all();",CIRCOM_CALC_WIT,CTX_INDEX));	    
-        run_body.push("}".to_string());
-        //parallelism
-        run_body.push("ctx->numThreadMutex.lock();".to_string());
-	    run_body.push("ctx->numThread--;".to_string());
-        //run_body.push(format!("printf(\"%i \\n\", ctx->numThread);"));
-        run_body.push("ctx->numThreadMutex.unlock();".to_string());
-	    run_body.push("ctx->ntcvs.notify_one();".to_string());
-	}
+            run_body.push(format!(
+                "for (uint i = 0; i < {}; i++) {{",
+                &self.number_of_components.to_string()
+            ));
+            run_body.push("if (ctx->componentMemory[ctx_index].sbct[i].joinable()) {".to_string());
+            run_body.push("ctx->componentMemory[ctx_index].sbct[i].join();".to_string());
+            run_body.push("}".to_string());
+            run_body.push("}".to_string());
+            run_body.push("}".to_string());
+        }
+        if parallel {
+            // parallelism
+            // set to true all outputs
+            run_body.push(format!(
+                "for (uint i = 0; i < {}; i++) {{",
+                &self.number_of_outputs.to_string()
+            ));
+            run_body.push(format!(
+                "{}->componentMemory[{}].mutexes[i].lock();",
+                CIRCOM_CALC_WIT, CTX_INDEX
+            ));
+            run_body.push(format!(
+                "{}->componentMemory[{}].outputIsSet[i]=true;",
+                CIRCOM_CALC_WIT, CTX_INDEX
+            ));
+            run_body.push(format!(
+                "{}->componentMemory[{}].mutexes[i].unlock();",
+                CIRCOM_CALC_WIT, CTX_INDEX
+            ));
+            run_body.push(format!(
+                "{}->componentMemory[{}].cvs[i].notify_all();",
+                CIRCOM_CALC_WIT, CTX_INDEX
+            ));
+            run_body.push("}".to_string());
+            //parallelism
+            run_body.push("ctx->numThreadMutex.lock();".to_string());
+            run_body.push("ctx->numThread--;".to_string());
+            //run_body.push(format!("printf(\"%i \\n\", ctx->numThread);"));
+            run_body.push("ctx->numThreadMutex.unlock();".to_string());
+            run_body.push("ctx->ntcvs.notify_one();".to_string());
+        }
 
         // to release the memory of its subcomponents
-        run_body.push(format!("for (uint i = 0; i < {}; i++){{", &self.number_of_components.to_string()));
+        run_body.push(format!(
+            "for (uint i = 0; i < {}; i++){{",
+            &self.number_of_components.to_string()
+        ));
         run_body.push(format!(
             "uint index_subc = {}->componentMemory[{}].subcomponents[i];",
             CIRCOM_CALC_WIT,
             ctx_index(),
         ));
-        run_body.push(format!("if (index_subc != 0){};", 
+        run_body.push(format!(
+            "if (index_subc != 0){};",
             build_call(
-                "release_memory_component".to_string(), 
+                "release_memory_component".to_string(),
                 vec![CIRCOM_CALC_WIT.to_string(), "index_subc".to_string()]
-            )));
-        
+            )
+        ));
+
         run_body.push("}".to_string());
         let run_fun = build_callable(run_header, run_params, run_body);
         vec![create_fun, run_fun]

--- a/compiler/src/compiler_interface.rs
+++ b/compiler/src/compiler_interface.rs
@@ -45,7 +45,7 @@ pub fn write_c(circuit: &Circuit, c_folder: &str, c_run_name: &str, c_file: &str
 fn produce_debug_output(circuit: &Circuit) -> Result<(), ()> {
     use std::io::Write;
     use std::path::Path;
-    let path = format!("ir_log");
+    let path = "ir_log".to_string();
     if Path::new(&path).is_dir() {
         std::fs::remove_dir_all(&path).map_err(|_err| {})?;
     }

--- a/compiler/src/compiler_interface.rs
+++ b/compiler/src/compiler_interface.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub wat_flag: bool,
 }
 
+#[allow(clippy::result_unit_err)]
 pub fn run_compiler(vcp: VCP, config: Config, version: &str) -> Result<Circuit, ()> {
     let flags = CompilationFlags { main_inputs_log: config.produce_input_log, wat_flag: config.wat_flag };
     let circuit = Circuit::build(vcp, flags, version);
@@ -18,6 +19,7 @@ pub fn run_compiler(vcp: VCP, config: Config, version: &str) -> Result<Circuit, 
     Ok(circuit)
 }
 
+#[allow(clippy::result_unit_err)]
 pub fn write_wasm(circuit: &Circuit, js_folder: &str, wasm_name: &str, file: &str) -> Result<(), ()> {
     use std::path::Path;
     if Path::new(js_folder).is_dir() {
@@ -29,6 +31,7 @@ pub fn write_wasm(circuit: &Circuit, js_folder: &str, wasm_name: &str, file: &st
     circuit.produce_wasm(js_folder, wasm_name, &mut writer)
 }
 
+#[allow(clippy::result_unit_err)]
 pub fn write_c(circuit: &Circuit, c_folder: &str, c_run_name: &str, c_file: &str, dat_file: &str) -> Result<(), ()> {
     use std::path::Path;
     if Path::new(c_folder).is_dir() {

--- a/compiler/src/hir/merger.rs
+++ b/compiler/src/hir/merger.rs
@@ -29,7 +29,7 @@ fn produce_vcf(vcp: &VCP, state: &mut State) {
     let mut index = 0;
     while index < state.vcf_collector.len() {
         state.external_signals = build_component_info(&vec![]);
-        let mut env = build_environment(&vec![], &state.vcf_collector[index].params_types);
+        let mut env = build_environment(&[], &state.vcf_collector[index].params_types);
         let body = state.vcf_collector[index].body.clone();
         produce_vcf_stmt(&body, state, &mut env);
         index += 1;
@@ -38,7 +38,7 @@ fn produce_vcf(vcp: &VCP, state: &mut State) {
 
 fn link_circuit(vcp: &mut VCP, state: &mut State) {
     for node in &mut vcp.templates {
-        let mut env = build_environment(&node.header, &vec![]);
+        let mut env = build_environment(&node.header, &[]);
         state.external_signals = build_component_info(&node.triggers);
         link_stmt(&mut node.code, state, &mut env);
     }
@@ -163,7 +163,7 @@ fn produce_vcf_log_call(stmt: &Statement, state: &mut State, environment: &E) {
             if let LogArgument::LogExp(arg) = arglog {
                 produce_vcf_expr(arg, state, environment);
             }
-            else {}// unimplemented!(); }
+            // unimplemented!(); }
         }
     } else {
         unreachable!();
@@ -646,7 +646,7 @@ fn cast_type_array(expr: &Expression, state: &State, environment: &E) -> VCT {
         result.append(&mut inner_type);
         result
     } else if let UniformArray { value, dimension, .. } = expr {
-        let usable_dimension = if let Option::Some(dimension) = cast_dimension(&dimension) {
+        let usable_dimension = if let Option::Some(dimension) = cast_dimension(dimension) {
             dimension
         } else {
             unreachable!()

--- a/compiler/src/hir/sugar_cleaner.rs
+++ b/compiler/src/hir/sugar_cleaner.rs
@@ -257,7 +257,7 @@ fn extend_prefix(expr: &mut Expression, state: &mut State, context: &Context) ->
     use Expression::PrefixOp;
     if let PrefixOp { rhe, .. } = expr {
         let mut extended = extend_expression(rhe, state, context);
-        let mut expr = vec![*rhe.clone()];
+        let mut expr = vec![rhe.as_ref().clone()];
         sugar_filter(&mut expr, state, &mut extended.initializations);
         *rhe = Box::new(expr.pop().unwrap());
         extended
@@ -270,7 +270,7 @@ fn extend_parallel(expr: &mut Expression, state: &mut State, context: &Context) 
     use Expression::ParallelOp;
     if let ParallelOp { rhe, .. } = expr {
         let mut extended = extend_expression(rhe, state, context);
-        let mut expr = vec![*rhe.clone()];
+        let mut expr = vec![rhe.as_ref().clone()];
         sugar_filter(&mut expr, state, &mut extended.initializations);
         *rhe = Box::new(expr.pop().unwrap());
         extended
@@ -291,7 +291,7 @@ fn extend_infix(expr: &mut Expression, state: &mut State, context: &Context) -> 
         let mut rh_expand = extend_expression(rhe, state, context);
         lh_expand.initializations.append(&mut rh_expand.initializations);
         let mut extended = lh_expand;
-        let mut expr = vec![*lhe.clone(), *rhe.clone()];
+        let mut expr = vec![lhe.as_ref().clone(), rhe.as_ref().clone()];
         sugar_filter(&mut expr, state, &mut extended.initializations);
 
         let mut expr_rhe = expr.pop().unwrap();
@@ -348,7 +348,7 @@ fn extend_switch(expr: &mut Expression, state: &mut State, context: &Context) ->
         let mut false_expand = extend_expression(if_false, state, context);
         true_expand.initializations.append(&mut false_expand.initializations);
         let mut extended = true_expand;
-        let mut expr = vec![*if_true.clone(), *if_false.clone()];
+        let mut expr = vec![if_true.as_ref().clone(), if_false.as_ref().clone()];
         sugar_filter(&mut expr, state, &mut extended.initializations);
         *if_false = Box::new(expr.pop().unwrap());
         *if_true = Box::new(expr.pop().unwrap());
@@ -373,7 +373,7 @@ fn extend_array(expr: &mut Expression, state: &mut State, context: &Context) -> 
         let mut dimension_expand = extend_expression(dimension, state, context);
         value_expand.initializations.append(&mut dimension_expand.initializations);
         let mut extended = value_expand;
-        let mut expr = vec![*value.clone(), *dimension.clone()];
+        let mut expr = vec![value.as_ref().clone(), dimension.as_ref().clone()];
         sugar_filter(&mut expr, state, &mut extended.initializations);
         *dimension = Box::new(expr.pop().unwrap());
         *value = Box::new(expr.pop().unwrap());
@@ -649,7 +649,7 @@ fn rhe_array_case(stmt: Statement, stmts: &mut Vec<Statement>) {
                     var: var.clone(),
                     access: accessed_with,
                     meta: meta.clone(),
-                    rhe: *value.clone(),
+                    rhe: value.as_ref().clone(),
                 };
                 stmts.push(sub);
                 index += 1;
@@ -699,7 +699,7 @@ fn lhe_array_ce(meta: &Meta, expr_array: &Expression, other_expr: &Expression, s
             for item in values_l {
                 let ce = ConstraintEquality {
                     lhe: item.clone(),
-                    rhe: *value.clone(),
+                    rhe: value.as_ref().clone(),
                     meta: meta.clone(),
                 };
                 stmts.push(ce);

--- a/compiler/src/hir/sugar_cleaner.rs
+++ b/compiler/src/hir/sugar_cleaner.rs
@@ -573,7 +573,7 @@ fn rhe_switch_case(stmt: Statement, stmts: &mut Vec<Statement>) {
                 meta: meta.clone(),
                 var: var.clone(),
                 access: access.clone(),
-                op: op.clone(),
+                op,
                 rhe: *if_true,
             };
             if_assigns.push(sub_if);

--- a/compiler/src/hir/type_inference.rs
+++ b/compiler/src/hir/type_inference.rs
@@ -203,13 +203,13 @@ fn infer_type_array(expr: &Expression, state: &State, context: &mut SearchInfo) 
             lengths
         })
     } else if let UniformArray { value, dimension, .. } = expr {
-        let usable_dimension = if let Option::Some(dimension) = cast_dimension(&dimension) {
+        let usable_dimension = if let Option::Some(dimension) = cast_dimension(dimension) {
             dimension
         } else {
             unreachable!()
         };
         let mut lengths = vec![usable_dimension];
-        let with_type = infer_type_expresion(&value, state, context);
+        let with_type = infer_type_expresion(value, state, context);
         with_type.map(|mut l| {
             lengths.append(&mut l);
             lengths
@@ -231,9 +231,7 @@ fn infer_type_call(expr: &Expression, state: &State, context: &mut SearchInfo) -
             let body = &state.generic_functions.get(id).unwrap().body;
             let names = &state.generic_functions.get(id).unwrap().params_names;
             let arg_types = infer_args(args, state, context);
-            if arg_types.is_none() {
-                return Option::None;
-            }
+            arg_types.as_ref()?;
             let arg_types = arg_types.unwrap();
             for arg_type in arg_types {
                 context.environment.add_variable(&names[index], arg_type);

--- a/compiler/src/hir/type_inference.rs
+++ b/compiler/src/hir/type_inference.rs
@@ -2,7 +2,7 @@ use super::analysis_utilities::*;
 use super::very_concrete_program::*;
 use program_structure::ast::*;
 use std::collections::HashSet;
-use num_traits::{ToPrimitive};
+use num_traits::ToPrimitive;
 
 struct SearchInfo {
     environment: E,
@@ -20,6 +20,7 @@ pub fn infer_function_result(id: &str, params: Vec<Param>, state: &State) -> VCT
 }
 
 fn infer_type_stmt(stmt: &Statement, state: &State, context: &mut SearchInfo) -> Option<VCT> {
+    #[allow(clippy::if_same_then_else)]
     if stmt.is_return() {
         infer_type_return(stmt, state, context)
     } else if stmt.is_block() {
@@ -129,6 +130,7 @@ fn infer_type_while(stmt: &Statement, state: &State, context: &mut SearchInfo) -
 }
 
 fn infer_type_expresion(expr: &Expression, state: &State, context: &mut SearchInfo) -> Option<VCT> {
+    #[allow(clippy::if_same_then_else)]
     if expr.is_call() {
         infer_type_call(expr, state, context)
     } else if expr.is_variable() {
@@ -227,15 +229,13 @@ fn infer_type_call(expr: &Expression, state: &State, context: &mut SearchInfo) -
         } else {
             context.open_calls.insert(id.clone());
             context.environment.add_variable_block();
-            let mut index = 0;
             let body = &state.generic_functions.get(id).unwrap().body;
             let names = &state.generic_functions.get(id).unwrap().params_names;
             let arg_types = infer_args(args, state, context);
             arg_types.as_ref()?;
             let arg_types = arg_types.unwrap();
-            for arg_type in arg_types {
+            for (index, arg_type) in arg_types.into_iter().enumerate() {
                 context.environment.add_variable(&names[index], arg_type);
-                index += 1;
             }
             let inferred = infer_type_stmt(body, state, context);
             context.environment.remove_variable_block();

--- a/compiler/src/intermediate_representation/branch_bucket.rs
+++ b/compiler/src/intermediate_representation/branch_bucket.rs
@@ -59,7 +59,7 @@ impl WriteWasm for BranchBucket {
         if producer.needs_comments() {
             instructions.push(";; branch bucket".to_string());
 	}
-        if self.if_branch.len() > 0 {
+        if !self.if_branch.is_empty() {
             let mut instructions_cond = self.cond.produce_wasm(producer);
             instructions.append(&mut instructions_cond);
             instructions.push(call("$Fr_isTrue"));
@@ -68,7 +68,7 @@ impl WriteWasm for BranchBucket {
                 let mut instructions_if = ins.produce_wasm(producer);
                 instructions.append(&mut instructions_if);
             }
-            if self.else_branch.len() > 0 {
+            if !self.else_branch.is_empty() {
                 instructions.push(add_else());
                 for ins in &self.else_branch {
                     let mut instructions_else = ins.produce_wasm(producer);
@@ -76,20 +76,18 @@ impl WriteWasm for BranchBucket {
                 }
             }
 	    instructions.push(add_end());
-        } else {
-            if self.else_branch.len() > 0 {
-                let mut instructions_cond = self.cond.produce_wasm(producer);
-                instructions.append(&mut instructions_cond);
-                instructions.push(call("$Fr_isTrue"));
-                instructions.push(eqz32());
-                instructions.push(add_if());
-                for ins in &self.else_branch {
-                    let mut instructions_else = ins.produce_wasm(producer);
-                    instructions.append(&mut instructions_else);
-                }
-		instructions.push(add_end());
-            }
-        }
+        } else if !self.else_branch.is_empty() {
+                        let mut instructions_cond = self.cond.produce_wasm(producer);
+                        instructions.append(&mut instructions_cond);
+                        instructions.push(call("$Fr_isTrue"));
+                        instructions.push(eqz32());
+                        instructions.push(add_if());
+                        for ins in &self.else_branch {
+                            let mut instructions_else = ins.produce_wasm(producer);
+                            instructions.append(&mut instructions_else);
+                        }
+        		instructions.push(add_end());
+                    }
         if producer.needs_comments() {
             instructions.push(";; end of branch bucket".to_string());
 	}

--- a/compiler/src/intermediate_representation/call_bucket.rs
+++ b/compiler/src/intermediate_representation/call_bucket.rs
@@ -55,8 +55,8 @@ impl ToString for CallBucket {
         let line = self.line.to_string();
         let template_id = self.message_id.to_string();
 	let ret = match &self.return_info {
-            ReturnType::Intermediate { op_aux_no } => {format!("Intermediate({})",op_aux_no.to_string())}
-	    _ => {format!("Final")}
+            ReturnType::Intermediate { op_aux_no } => {format!("Intermediate({})",op_aux_no)}
+	    _ => {"Final".to_string()}
 	};
         let mut args = "".to_string();
         for i in &self.arguments {
@@ -73,7 +73,7 @@ impl WriteWasm for CallBucket {
         if producer.needs_comments() {
             instructions.push(";; call bucket".to_string());
 	}
-        if self.arguments.len() > 0 {
+        if !self.arguments.is_empty() {
             let local_info_size_u32 = producer.get_local_info_size_u32();
             instructions.push(set_constant("0"));
             instructions.push(load32(None)); // current stack size
@@ -334,8 +334,8 @@ impl WriteWasm for CallBucket {
                                 instructions.push(get_local(producer.get_sub_cmp_tag()));
                                 instructions.push(load32(None)); // get template id
                                 instructions.push(call_indirect(
-                                    &"$runsmap".to_string(),
-                                    &"(type $_t_i32ri32)".to_string(),
+                                    "$runsmap",
+                                    "(type $_t_i32ri32)",
                                 ));
                                 instructions.push(tee_local(producer.get_merror_tag()));
                                 instructions.push(add_if());
@@ -414,7 +414,7 @@ impl WriteC for CallBucket {
 		if let AddressType::SubcmpSignal { cmp_address, .. } = &data.dest_address_type {
 		    let (mut cmp_prologue, cmp_index) = cmp_address.produce_c(producer, parallel);
 		    prologue.append(&mut cmp_prologue);
-		    prologue.push(format!("{{"));
+		    prologue.push("{".to_string());
 	            prologue.push(format!("uint {} = {};",  cmp_index_ref, cmp_index));
 	        
 		}
@@ -428,22 +428,22 @@ impl WriteC for CallBucket {
 			let mut map_access = format!("{}->{}[{}].defs[{}].offset",
 						     circom_calc_wit(), template_ins_2_io_info(),
 						     template_id_in_component(sub_component_pos_in_memory.clone()),
-						     signal_code.to_string());
-			if indexes.len()>0 {
-			    map_prologue.push(format!("{{"));
-			    map_prologue.push(format!("uint map_index_aux[{}];",indexes.len().to_string()));		    
+						     signal_code);
+			if !indexes.is_empty() {
+			    map_prologue.push("{".to_string());
+			    map_prologue.push(format!("uint map_index_aux[{}];",indexes.len()));		    
 			    let (mut index_code_0, mut map_index) = indexes[0].produce_c(producer, parallel);
 			    map_prologue.append(&mut index_code_0);
 			    map_prologue.push(format!("map_index_aux[0]={};",map_index));
-			    map_index = format!("map_index_aux[0]");
+			    map_index = "map_index_aux[0]".to_string();
 			    for i in 1..indexes.len() {
 				let (mut index_code, index_exp) = indexes[i].produce_c(producer, parallel);
 				map_prologue.append(&mut index_code);
-				map_prologue.push(format!("map_index_aux[{}]={};",i.to_string(),index_exp));
+				map_prologue.push(format!("map_index_aux[{}]={};",i,index_exp));
 				map_index = format!("({})*{}->{}[{}].defs[{}].lengths[{}]+map_index_aux[{}]",
 						    map_index, circom_calc_wit(), template_ins_2_io_info(),
 						    template_id_in_component(sub_component_pos_in_memory.clone()),
-						    signal_code.to_string(),(i-1).to_string(),i.to_string());
+						    signal_code,(i-1),i);
 			    }
 			    map_access = format!("{}+{}",map_access,map_index);
 			}
@@ -475,22 +475,22 @@ impl WriteC for CallBucket {
                 call_arguments.push(data.context.size.to_string());
                 prologue.push(format!("{};", build_call(self.symbol.clone(), call_arguments)));
 		if let LocationRule::Mapped { indexes, .. } = &data.dest {
-		    if indexes.len() > 0 {
-    			prologue.push(format!("}}"));
+		    if !indexes.is_empty() {
+    			prologue.push("}".to_string());
 		    }
 		}
 		// if output and parallel send notify
 		if let AddressType::Signal = &data.dest_address_type {
 		    if parallel.unwrap()  && data.dest_is_output {
 			if data.context.size > 0 {
-			    prologue.push(format!("{{"));
+			    prologue.push("{".to_string());
 			    prologue.push(format!("for (int i = 0; i < {}; i++) {{",data.context.size));
 			    prologue.push(format!("{}->componentMemory[{}].mutexes[{}+i].lock();",CIRCOM_CALC_WIT,CTX_INDEX,dest_index.clone()));
 			    prologue.push(format!("{}->componentMemory[{}].outputIsSet[{}+i]=true;",CIRCOM_CALC_WIT,CTX_INDEX,dest_index.clone()));
 			    prologue.push(format!("{}->componentMemory[{}].mutexes[{}+i].unlock();",CIRCOM_CALC_WIT,CTX_INDEX,dest_index.clone()));
 			    prologue.push(format!("{}->componentMemory[{}].cvs[{}+i].notify_all();",CIRCOM_CALC_WIT,CTX_INDEX,dest_index.clone()));
-			    prologue.push(format!("}}"));
-			    prologue.push(format!("}}"));
+			    prologue.push("}".to_string());
+			    prologue.push("}".to_string());
 			} else {
 			    prologue.push(format!("{}->componentMemory[{}].mutexes[{}].lock();",CIRCOM_CALC_WIT,CTX_INDEX,dest_index.clone()));
 			    prologue.push(format!("{}->componentMemory[{}].outputIsSet[{}]=true;",CIRCOM_CALC_WIT,CTX_INDEX,dest_index.clone()));
@@ -537,7 +537,7 @@ impl WriteC for CallBucket {
                         thread_call_instr.push(format!("{}->componentMemory[{}].sbct[{}] = std::thread({},{});",CIRCOM_CALC_WIT,CTX_INDEX,cmp_index_ref, sub_cmp_call_name, argument_list(sub_cmp_call_arguments)));
                         thread_call_instr.push(format!("std::unique_lock<std::mutex> lkt({}->numThreadMutex);",CIRCOM_CALC_WIT));
                         thread_call_instr.push(format!("{}->ntcvs.wait(lkt, [{}]() {{return  {}->numThread <  {}->maxThread; }});",CIRCOM_CALC_WIT,CIRCOM_CALC_WIT,CIRCOM_CALC_WIT,CIRCOM_CALC_WIT));
-                        thread_call_instr.push(format!("ctx->numThread++;"));
+                        thread_call_instr.push("ctx->numThread++;".to_string());
                         //thread_call_instr.push(format!("printf(\"%i \\n\", ctx->numThread);"));
                         thread_call_instr
 
@@ -586,7 +586,7 @@ impl WriteC for CallBucket {
                     call_instructions.push(format!("{}->componentMemory[{}].sbct[{}] = std::thread({},{});",CIRCOM_CALC_WIT,CTX_INDEX,cmp_index_ref, sub_cmp_call_name, argument_list(sub_cmp_call_arguments.clone())));
                     call_instructions.push(format!("std::unique_lock<std::mutex> lkt({}->numThreadMutex);",CIRCOM_CALC_WIT));
                     call_instructions.push(format!("{}->ntcvs.wait(lkt, [{}]() {{return {}->numThread <  {}->maxThread; }});",CIRCOM_CALC_WIT,CIRCOM_CALC_WIT,CIRCOM_CALC_WIT,CIRCOM_CALC_WIT));
-                    call_instructions.push(format!("ctx->numThread++;"));
+                    call_instructions.push("ctx->numThread++;".to_string());
                     //call_instructions.push(format!("printf(\"%i \\n\", ctx->numThread);"));
                     if let StatusInput::Unknown = status {
                         let sub_cmp_counter_decrease_andcheck = format!("!({})",sub_cmp_counter_decrease);
@@ -602,7 +602,7 @@ impl WriteC for CallBucket {
                     }
                     // end of case parallel
 
-                    prologue.push(format!("}} else {{"));
+                    prologue.push("} else {".to_string());
                     
                     // case not parallel
                     let sub_cmp_call_name = if let LocationRule::Indexed { .. } = &data.dest {
@@ -627,7 +627,7 @@ impl WriteC for CallBucket {
                         prologue.append(&mut call_instructions);
                     }
 
-                    prologue.push(format!("}}"));
+                    prologue.push("}".to_string());
                 }
 			}
             } else {
@@ -637,7 +637,7 @@ impl WriteC for CallBucket {
                     _ => (),
                 }
                 if let AddressType::SubcmpSignal { .. } = &data.dest_address_type {
-	             prologue.push(format!("}}"));
+	             prologue.push("}".to_string());
 	        }
                 result = "".to_string();
             }

--- a/compiler/src/intermediate_representation/compute_bucket.rs
+++ b/compiler/src/intermediate_representation/compute_bucket.rs
@@ -351,7 +351,7 @@ impl WriteC for ComputeBucket {
                 let mut arguments = vec![result_ref.clone()];
                 let operands_copy = operands.clone();
                 arguments.append(&mut operands);
-                compute_c.push(format!("{}; // line circom {}", build_call(operator.clone(), arguments),self.line.to_string()));
+                compute_c.push(format!("{}; // line circom {}", build_call(operator.clone(), arguments),self.line));
                 if *n > 1 {
                     compute_c.push(format!("{} = 1;", index_multiple_eq()));
                     compute_c.push(format!("while({} < {} && Fr_isTrue({})) {{", index_multiple_eq(), n, result_ref));
@@ -361,9 +361,9 @@ impl WriteC for ComputeBucket {
                         operands.push(format!("{} + {}", operand, index_multiple_eq()));
                     }
                     arguments.append(&mut operands);
-                    compute_c.push(format!("{}; // line circom {}", build_call(operator.clone(), arguments),self.line.to_string()));
+                    compute_c.push(format!("{}; // line circom {}", build_call(operator.clone(), arguments),self.line));
                     compute_c.push(format!("{}++;", index_multiple_eq()));
-                    compute_c.push(format!("}}"));
+                    compute_c.push("}".to_string());
                     
                 }
                 result = result_ref;
@@ -378,7 +378,7 @@ impl WriteC for ComputeBucket {
                 let result_ref = format!("&{}", expaux(exp_aux_index.clone()));
                 let mut arguments = vec![result_ref.clone()];
                 arguments.append(&mut operands);
-                compute_c.push(format!("{}; // line circom {}", build_call(operator, arguments),self.line.to_string()));
+                compute_c.push(format!("{}; // line circom {}", build_call(operator, arguments),self.line));
 
                 //value address
                 result = result_ref;

--- a/compiler/src/intermediate_representation/create_component_bucket.rs
+++ b/compiler/src/intermediate_representation/create_component_bucket.rs
@@ -212,7 +212,7 @@ impl WriteC for CreateCmpBucket {
         instructions.push("{".to_string());
         instructions.push(format!("uint aux_create = {};", scmp_idx));
         instructions.push(format!("int aux_cmp_num = {}+{}+1;", self.component_offset, CTX_INDEX));
-        instructions.push(format!("uint csoffset = {}+{};", MY_SIGNAL_START.to_string(), self.signal_offset));
+        instructions.push(format!("uint csoffset = {}+{};", MY_SIGNAL_START, self.signal_offset));
         if self.number_of_cmp > 1{
             instructions.push(format!("uint aux_dimensions[{}] = {};", self.dimensions.len(), set_list(self.dimensions.clone())));
         }
@@ -228,7 +228,7 @@ impl WriteC for CreateCmpBucket {
             instructions.push(format!("for (uint i = 0; i < {}; i++) {{", self.number_of_cmp));
             // update the value of the the parallel status if it is not uniform parallel using the array aux_parallel
             if self.uniform_parallel.is_none(){
-                instructions.push(format!("bool status_parallel = aux_parallel[i];"));
+                instructions.push("bool status_parallel = aux_parallel[i];".to_string());
             }
         }
         // generate array with the positions that are actually created if there are empty components
@@ -236,23 +236,23 @@ impl WriteC for CreateCmpBucket {
         else{
             instructions.push(format!("uint aux_positions [{}]= {};", self.defined_positions.len(), set_list(self.defined_positions.iter().map(|(x, _y)| *x).collect())));
             instructions.push(format!("for (uint i_aux = 0; i_aux < {}; i_aux++) {{",  self.defined_positions.len()));
-            instructions.push(format!("uint i = aux_positions[i_aux];"));
+            instructions.push("uint i = aux_positions[i_aux];".to_string());
             // update the value of the the parallel status if it is not uniform parallel using the array aux_parallel
             if self.uniform_parallel.is_none(){
-                instructions.push(format!("bool status_parallel = aux_parallel[i_aux];"));
+                instructions.push("bool status_parallel = aux_parallel[i_aux];".to_string());
             }
         }
 
         if self.number_of_cmp > 1{
             instructions.push(
                 format!("std::string new_cmp_name = \"{}\"+{};",
-                 self.name_subcomponent.to_string(),
+                 self.name_subcomponent,
                  generate_my_array_position("aux_dimensions".to_string(), self.dimensions.len().to_string(), "i".to_string())
                 )
             );
         }
         else {
-            instructions.push(format!("std::string new_cmp_name = \"{}\";", self.name_subcomponent.to_string()));
+            instructions.push(format!("std::string new_cmp_name = \"{}\";", self.name_subcomponent));
         }
         let create_args = vec![
             "csoffset".to_string(), 

--- a/compiler/src/intermediate_representation/ir_interface.rs
+++ b/compiler/src/intermediate_representation/ir_interface.rs
@@ -97,12 +97,7 @@ impl ObtainMeta for Instruction {
 impl CheckCompute for Instruction {
     fn has_compute_in(&self) -> bool {
         use Instruction::*;
-        match self {
-	    Load(_v) => {true
-	    },
-	    Compute(_) => true,
-	    _ => false,
-        }
+        matches!(self, Load(_) | Compute(_))
     }
 }
 

--- a/compiler/src/intermediate_representation/load_bucket.rs
+++ b/compiler/src/intermediate_representation/load_bucket.rs
@@ -197,8 +197,8 @@ impl WriteC for LoadBucket {
 		let mut map_access = format!("{}->{}[{}].defs[{}].offset",
 					     circom_calc_wit(), template_ins_2_io_info(),
 					     template_id_in_component(sub_component_pos_in_memory.clone()),
-					     signal_code.to_string());
-		if indexes.len()>0 {
+					     signal_code);
+		if !indexes.is_empty() {
 		    let (mut index_code_0, mut map_index) = indexes[0].produce_c(producer, parallel);
 		    map_prologue.append(&mut index_code_0);
 		    for i in 1..indexes.len() {
@@ -207,7 +207,7 @@ impl WriteC for LoadBucket {
 			map_index = format!("({})*{}->{}[{}].defs[{}].lengths[{}]+{}",
 					    map_index, circom_calc_wit(), template_ins_2_io_info(),
 					    template_id_in_component(sub_component_pos_in_memory.clone()),
-					    signal_code.to_string(), (i-1).to_string(),index_exp);
+					    signal_code, (i-1),index_exp);
 		    }
 		    map_access = format!("{}+{}",map_access,map_index);
 		}
@@ -228,16 +228,16 @@ impl WriteC for LoadBucket {
 		if *is_output {
             if uniform_parallel_value.is_some(){
                 if uniform_parallel_value.unwrap(){
-                    prologue.push(format!("{{"));
+                    prologue.push("{".to_string());
 		            prologue.push(format!("int aux1 = {};",cmp_index_ref.clone()));
 		            prologue.push(format!("int aux2 = {};",src_index.clone()));
                     // check each one of the outputs of the assignment, we add i to check them one by one
                     prologue.push(format!("for (int i = 0; i < {}; i++) {{",self.context.size));
-                    prologue.push(format!("ctx->numThreadMutex.lock();"));
-                    prologue.push(format!("ctx->numThread--;"));
+                    prologue.push("ctx->numThreadMutex.lock();".to_string());
+                    prologue.push("ctx->numThread--;".to_string());
                     //prologue.push(format!("printf(\"%i \\n\", ctx->numThread);"));
-                    prologue.push(format!("ctx->numThreadMutex.unlock();"));
-                    prologue.push(format!("ctx->ntcvs.notify_one();"));	 
+                    prologue.push("ctx->numThreadMutex.unlock();".to_string());
+                    prologue.push("ctx->ntcvs.notify_one();".to_string());	 
 		            prologue.push(format!(
                         "std::unique_lock<std::mutex> lk({}->componentMemory[{}[aux1]].mutexes[aux2 + i]);",
                         CIRCOM_CALC_WIT, MY_SUBCOMPONENTS)
@@ -249,10 +249,10 @@ impl WriteC for LoadBucket {
                     );
                     prologue.push(format!("std::unique_lock<std::mutex> lkt({}->numThreadMutex);",CIRCOM_CALC_WIT));
                     prologue.push(format!("{}->ntcvs.wait(lkt, [{}]() {{return {}->numThread <  {}->maxThread; }});",CIRCOM_CALC_WIT,CIRCOM_CALC_WIT,CIRCOM_CALC_WIT,CIRCOM_CALC_WIT));
-                    prologue.push(format!("ctx->numThread++;"));
+                    prologue.push("ctx->numThread++;".to_string());
                     //prologue.push(format!("printf(\"%i \\n\", ctx->numThread);"));
-                    prologue.push(format!("}}"));
-		            prologue.push(format!("}}"));
+                    prologue.push("}".to_string());
+		            prologue.push("}".to_string());
                 }
             }
             // Case we only know if it is parallel at execution
@@ -264,16 +264,16 @@ impl WriteC for LoadBucket {
                 ));
 
                 // case parallel
-                prologue.push(format!("{{"));
+                prologue.push("{".to_string());
 		        prologue.push(format!("int aux1 = {};",cmp_index_ref.clone()));
 		        prologue.push(format!("int aux2 = {};",src_index.clone()));
 		        // check each one of the outputs of the assignment, we add i to check them one by one
                 prologue.push(format!("for (int i = 0; i < {}; i++) {{",self.context.size));
-                prologue.push(format!("ctx->numThreadMutex.lock();"));
-                prologue.push(format!("ctx->numThread--;"));
+                prologue.push("ctx->numThreadMutex.lock();".to_string());
+                prologue.push("ctx->numThread--;".to_string());
                 //prologue.push(format!("printf(\"%i \\n\", ctx->numThread);"));
-                prologue.push(format!("ctx->numThreadMutex.unlock();"));
-                prologue.push(format!("ctx->ntcvs.notify_one();"));	 
+                prologue.push("ctx->numThreadMutex.unlock();".to_string());
+                prologue.push("ctx->ntcvs.notify_one();".to_string());	 
 	            prologue.push(format!(
                         "std::unique_lock<std::mutex> lk({}->componentMemory[{}[aux1]].mutexes[aux2 + i]);",
                         CIRCOM_CALC_WIT, MY_SUBCOMPONENTS)
@@ -285,14 +285,14 @@ impl WriteC for LoadBucket {
                     );
                 prologue.push(format!("std::unique_lock<std::mutex> lkt({}->numThreadMutex);",CIRCOM_CALC_WIT));
                 prologue.push(format!("{}->ntcvs.wait(lkt, [{}]() {{return {}->numThread <  {}->maxThread; }});",CIRCOM_CALC_WIT,CIRCOM_CALC_WIT,CIRCOM_CALC_WIT,CIRCOM_CALC_WIT));
-                prologue.push(format!("ctx->numThread++;"));
+                prologue.push("ctx->numThread++;".to_string());
                 //prologue.push(format!("printf(\"%i \\n\", ctx->numThread);"));
-                prologue.push(format!("}}"));
-		        prologue.push(format!("}}"));
+                prologue.push("}".to_string());
+		        prologue.push("}".to_string());
                 
                 // end of case parallel, in case no parallel we do nothing
 
-                prologue.push(format!("}}"));
+                prologue.push("}".to_string());
             }
         }
                 let sub_cmp_start = format!(

--- a/compiler/src/intermediate_representation/load_bucket.rs
+++ b/compiler/src/intermediate_representation/load_bucket.rs
@@ -138,12 +138,12 @@ impl WriteWasm for LoadBucket {
                                                              // compute de move with 2 or more dimensions
                             let mut instructions_idx0 = indexes[0].produce_wasm(producer);
                             instructions.append(&mut instructions_idx0); // start with dimension 0
-                            for i in 1..indexes.len() {
+                            for (i, item) in indexes.iter().enumerate().skip(1) {
                                 instructions.push(get_local(producer.get_io_info_tag()));
                                 let offsetdim = 4 * i;
                                 instructions.push(load32(Some(&offsetdim.to_string()))); // get size of ith dimension
                                 instructions.push(mul32()); // multiply the current move by size of the ith dimension
-                                let mut instructions_idxi = indexes[i].produce_wasm(producer);
+                                let mut instructions_idxi = item.produce_wasm(producer);
                                 instructions.append(&mut instructions_idxi);
                                 instructions.push(add32()); // add move upto dimension i
                             }
@@ -165,7 +165,7 @@ impl WriteWasm for LoadBucket {
 			}
                     }
                     _ => {
-                        assert!(false);
+                        unreachable!();
                     }
                 }
             }
@@ -201,20 +201,19 @@ impl WriteC for LoadBucket {
 		if !indexes.is_empty() {
 		    let (mut index_code_0, mut map_index) = indexes[0].produce_c(producer, parallel);
 		    map_prologue.append(&mut index_code_0);
-		    for i in 1..indexes.len() {
-			let (mut index_code, index_exp) = indexes[i].produce_c(producer, parallel);
-			map_prologue.append(&mut index_code);
-			map_index = format!("({})*{}->{}[{}].defs[{}].lengths[{}]+{}",
-					    map_index, circom_calc_wit(), template_ins_2_io_info(),
-					    template_id_in_component(sub_component_pos_in_memory.clone()),
-					    signal_code, (i-1),index_exp);
+		    for (i, item) in indexes.iter().enumerate().skip(1) {
+                let (mut index_code, index_exp) = item.produce_c(producer, parallel);
+                map_prologue.append(&mut index_code);
+                map_index = format!("({})*{}->{}[{}].defs[{}].lengths[{}]+{}",
+                            map_index, circom_calc_wit(), template_ins_2_io_info(),
+                            template_id_in_component(sub_component_pos_in_memory.clone()),
+                            signal_code, (i-1),index_exp);
 		    }
 		    map_access = format!("{}+{}",map_access,map_index);
 		}
                 (map_prologue, map_access)
 	    } else {
-		assert!(false);
-                (vec![], "".to_string())
+            unreachable!();
 	    };
         prologue.append(&mut src_prologue);
         let access = match &self.address_type {

--- a/compiler/src/intermediate_representation/log_bucket.rs
+++ b/compiler/src/intermediate_representation/log_bucket.rs
@@ -106,8 +106,7 @@ impl WriteC for LogBucket {
     fn produce_c(&self, producer: &CProducer, parallel: Option<bool>) -> (Vec<String>, String) {
         use c_code_generator::*;
         let mut log_c = Vec::new();
-        let mut index = 0;
-        for logarg in &self.argsprint {
+        for (index, logarg) in self.argsprint.iter().enumerate() {
             if let LogBucketArg::LogExp(exp) = logarg {
                 let (mut argument_code, argument_result) = exp.produce_c(producer, parallel);
                 let to_string_call = build_call("Fr_element2str".to_string(), vec![argument_result]);
@@ -122,8 +121,7 @@ impl WriteC for LogBucket {
                 log_c.push(format!("{};", print_c));
                 log_c.push(format!("{};", delete_temp));
                 log_c.push("}".to_string());
-            }
-            else if let LogBucketArg::LogStr(string_id) = logarg {
+            } else if let LogBucketArg::LogStr(string_id) = logarg {
                 let string_value = &producer.get_string_table()[*string_id];
 
                 let print_c =
@@ -134,8 +132,7 @@ impl WriteC for LogBucket {
                 log_c.push("{".to_string());
                 log_c.push(format!("{};", print_c));
                 log_c.push("}".to_string());
-            }
-            else{
+            } else {
                 unreachable!();
             }
             if index != self.argsprint.len() - 1 { 
@@ -148,7 +145,6 @@ impl WriteC for LogBucket {
                 log_c.push(format!("{};", print_c));
                 log_c.push("}".to_string());
             }
-            index += 1;
         }
         let print_end_line = build_call(
             "printf".to_string(), 

--- a/compiler/src/intermediate_representation/mod.rs
+++ b/compiler/src/intermediate_representation/mod.rs
@@ -15,4 +15,4 @@ mod value_bucket;
 
 pub mod ir_interface;
 pub mod translate;
-pub use ir_interface::{Instruction, InstructionList, InstructionPointer};
+pub use ir_interface::{InstructionList};

--- a/compiler/src/intermediate_representation/value_bucket.rs
+++ b/compiler/src/intermediate_representation/value_bucket.rs
@@ -39,7 +39,7 @@ impl ToString for ValueBucket {
         let template_id = self.message_id.to_string();
         let parse_as = self.parse_as.to_string();
         let op_aux_number = self.op_aux_no.to_string();
-        let value = self.value.clone();
+        let value = self.value;
         format!(
             "VALUE(line:{},template_id:{},as:{},op_number:{},value:{})",
             line, template_id, parse_as, op_aux_number, value

--- a/compiler/src/ir_processing/build_inputs_info.rs
+++ b/compiler/src/ir_processing/build_inputs_info.rs
@@ -1,5 +1,5 @@
 use crate::intermediate_representation::ir_interface::*;
-use std::collections::{HashSet};
+use std::collections::HashSet;
 
 type ComponentsSet = HashSet<String>;
 
@@ -256,15 +256,10 @@ pub fn visit_address_type(
                 found_unknown_address
             }
             else if let Value {..} = **cmp_address{
-                if found_unknown_address{
+                if found_unknown_address || inside_loop {
                     *input_information = Input{status: Unknown};
                     //println!("Poniendo un unknown en {}", cmp_address.to_string());
-                }
-                else if inside_loop {
-                    *input_information = Input{status: Unknown};
-                    //println!("Poniendo un unknown en {}", cmp_address.to_string());
-                }
-                else{
+                } else {
                     *input_information = Input{status: Last};
                     //println!("Poniendo un last en {}", cmp_address.to_string());
                 }

--- a/compiler/src/ir_processing/build_inputs_info.rs
+++ b/compiler/src/ir_processing/build_inputs_info.rs
@@ -75,16 +75,16 @@ pub fn visit_branch(
         inside_loop
     );
 
-    let known_component_both_branches: ComponentsSet = known_last_component_if.intersection(& known_last_component_else).map(|s| s.clone()).collect();
-    let known_component_one_branch: ComponentsSet = known_last_component_if.symmetric_difference(&known_last_component_else).map(|s| s.clone()).collect();
+    let known_component_both_branches: ComponentsSet = known_last_component_if.intersection(& known_last_component_else).cloned().collect();
+    let known_component_one_branch: ComponentsSet = known_last_component_if.symmetric_difference(&known_last_component_else).cloned().collect();
 
-    let mut new_unknown_component: ComponentsSet = unknown_last_component_if.union(&unknown_last_component_else).map(|s| s.clone()).collect();
-    new_unknown_component = new_unknown_component.union(&known_component_one_branch).map(|s| s.clone()).collect(); 
+    let mut new_unknown_component: ComponentsSet = unknown_last_component_if.union(&unknown_last_component_else).cloned().collect();
+    new_unknown_component = new_unknown_component.union(&known_component_one_branch).cloned().collect(); 
 
-    let joined_unknown_component: ComponentsSet = unknown_last_component.union(&new_unknown_component).map(|s| s.clone()).collect();
+    let joined_unknown_component: ComponentsSet = unknown_last_component.union(&new_unknown_component).cloned().collect();
 
-    *known_last_component = known_last_component.union(&known_component_both_branches).map(|s| s.clone()).collect();
-    *unknown_last_component =  joined_unknown_component.difference(&known_component_both_branches).map(|s| s.clone()).collect();
+    *known_last_component = known_last_component.union(&known_component_both_branches).cloned().collect();
+    *unknown_last_component =  joined_unknown_component.difference(&known_component_both_branches).cloned().collect();
     found_unknown_if || found_unknown_else
 }
 
@@ -152,10 +152,10 @@ pub fn visit_loop(
         true
     );
 
-    let new_unknown_component: ComponentsSet = known_last_component_loop.union(&unknown_last_component_loop).map(|s| s.clone()).collect();
+    let new_unknown_component: ComponentsSet = known_last_component_loop.union(&unknown_last_component_loop).cloned().collect();
 
-    *known_last_component = known_last_component.difference(&new_unknown_component).map(|s| s.clone()).collect();
-    *unknown_last_component = unknown_last_component.union(&new_unknown_component).map(|s| s.clone()).collect();
+    *known_last_component = known_last_component.difference(&new_unknown_component).cloned().collect();
+    *unknown_last_component = unknown_last_component.union(&new_unknown_component).cloned().collect();
     found_unknown_address_new
 }
 
@@ -255,31 +255,27 @@ pub fn visit_address_type(
                 //println!("Poniendo un unknown en {}", cmp_address.to_string());
                 found_unknown_address
             }
-            else{
-                if let Value {..} = **cmp_address{
-                    if found_unknown_address{
-                        *input_information = Input{status: Unknown};
-                        //println!("Poniendo un unknown en {}", cmp_address.to_string());
-                    }
-                    else{
-                        if inside_loop {
-                            *input_information = Input{status: Unknown};
-                            //println!("Poniendo un unknown en {}", cmp_address.to_string());
-                        }
-                        else{
-                            *input_information = Input{status: Last};
-                            //println!("Poniendo un last en {}", cmp_address.to_string());
-                        }
-                    }
-                    known_last_component.insert(cmp_address.to_string());
-                    unknown_last_component.remove(&cmp_address.to_string());
-                    found_unknown_address
-                }
-                else{
+            else if let Value {..} = **cmp_address{
+                if found_unknown_address{
                     *input_information = Input{status: Unknown};
                     //println!("Poniendo un unknown en {}", cmp_address.to_string());
-                    false
                 }
+                else if inside_loop {
+                    *input_information = Input{status: Unknown};
+                    //println!("Poniendo un unknown en {}", cmp_address.to_string());
+                }
+                else{
+                    *input_information = Input{status: Last};
+                    //println!("Poniendo un last en {}", cmp_address.to_string());
+                }
+                known_last_component.insert(cmp_address.to_string());
+                unknown_last_component.remove(&cmp_address.to_string());
+                found_unknown_address
+            }
+            else{
+                *input_information = Input{status: Unknown};
+                //println!("Poniendo un unknown en {}", cmp_address.to_string());
+                false
             }
         }
         else{

--- a/compiler/src/ir_processing/build_stack.rs
+++ b/compiler/src/ir_processing/build_stack.rs
@@ -75,8 +75,8 @@ pub fn build_compute(bucket: &mut ComputeBucket, mut fresh: usize) -> usize {
 
 pub fn build_load(bucket: &mut LoadBucket, fresh: usize) -> usize {
     let v0 = build_address_type(&mut bucket.address_type, fresh);
-    let v1 = build_location(&mut bucket.src, v0);
-    v1
+    
+    build_location(&mut bucket.src, v0)
 }
 
 pub fn build_create_cmp(bucket: &mut CreateCmpBucket, fresh: usize) -> usize {

--- a/constant_tracking/src/lib.rs
+++ b/constant_tracking/src/lib.rs
@@ -10,6 +10,15 @@ where
     constants: Vec<C>,
 }
 
+impl<C> Default for ConstantTracker<C>
+where
+    C: Eq + Hash + Clone,
+ {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<C> ConstantTracker<C>
 where
     C: Eq + Hash + Clone,

--- a/constraint_generation/src/compute_constants.rs
+++ b/constraint_generation/src/compute_constants.rs
@@ -89,9 +89,7 @@ fn treat_statement(stmt: &mut Statement, context: &Context, reports: &mut Report
         treat_declaration(stmt, context, reports, flags, prime)
     } else if stmt.is_substitution(){
         treat_substitution(stmt, context, reports, flags, prime)
-    } else{
-
-    }
+    } 
 }
 
 fn treat_init_block(stmt: &mut Statement, context: &Context, reports: &mut ReportCollection, flags: FlagsExecution, prime: &String) {
@@ -184,15 +182,14 @@ fn treat_expression(
 ){
     use Expression::{Number, UniformArray};
     if let UniformArray {meta, value, dimension} = expr{
-        let execution_response = treat_dimension(&dimension, context, reports, flags, prime);
+        let execution_response = treat_dimension(dimension, context, reports, flags, prime);
         if let Option::Some(v) = execution_response {
             **dimension = Number(meta.clone(), BigInt::from(v));
         } else {
             report_invalid_dimension(meta, reports);
         }
         treat_expression(value, context, reports, flags, prime)
-    } else{
-    }
+    } 
 }
 
 fn treat_dimension(

--- a/constraint_generation/src/environment_utils/component_representation.rs
+++ b/constraint_generation/src/environment_utils/component_representation.rs
@@ -325,14 +325,11 @@ impl ComponentRepresentation {
             true
         )?;
         let dim = SignalSlice::get_number_of_cells(new_value_slice);
-        match component.unassigned_inputs.get_mut(signal_name){
-            Some(left) => {
-                *left -= dim;
-                if *left == 0 {
-                    component.unassigned_inputs.remove(signal_name);
-                }
+        if let Some(left) = component.unassigned_inputs.get_mut(signal_name) {
+            *left -= dim;
+            if *left == 0 {
+                component.unassigned_inputs.remove(signal_name);
             }
-            None => {}
         }
 
         Result::Ok(())

--- a/constraint_generation/src/environment_utils/component_representation.rs
+++ b/constraint_generation/src/environment_utils/component_representation.rs
@@ -4,6 +4,7 @@ use crate::execution_data::ExecutedProgram;
 use std::collections::{BTreeMap,HashMap, HashSet};
 use crate::ast::Meta;
 
+#[derive(Default)]
 pub struct ComponentRepresentation {
     pub node_pointer: Option<NodePointer>,
     pub is_parallel: bool,
@@ -18,23 +19,7 @@ pub struct ComponentRepresentation {
     pub is_initialized: bool,
 }
 
-impl Default for ComponentRepresentation {
-    fn default() -> Self {
-        ComponentRepresentation {
-            node_pointer: Option::None,
-            is_parallel: false,
-            unassigned_inputs: HashMap::new(),
-            unassigned_tags: HashSet::new(),
-            to_assign_inputs: Vec::new(),
-            inputs: HashMap::new(),
-            inputs_tags: BTreeMap::new(),
-            outputs: HashMap::new(),
-            outputs_tags: BTreeMap::new(),
-            is_initialized: false,
-            meta: Option::None,
-        }
-    }
-}
+
 impl Clone for ComponentRepresentation {
     fn clone(&self) -> Self {
         ComponentRepresentation {
@@ -267,15 +252,13 @@ impl ComponentRepresentation {
         for (t, value) in tags_input{
             if !tags.contains_key(t){
                 return Result::Err(MemoryError::AssignmentMissingTags(signal_name.to_string(), t.clone()));
-            } else{
-                if is_first_assignment_signal{
-                    *value = tags.get(t).unwrap().clone();
-                }
-                else{
-                    // already given a value, check that it is the same
-                    if value != tags.get(t).unwrap(){
-                        return Result::Err(MemoryError::AssignmentTagInputTwice(signal_name.to_string(), t.clone()));
-                    }
+            } else if is_first_assignment_signal{
+                *value = tags.get(t).unwrap().clone();
+            }
+            else{
+                // already given a value, check that it is the same
+                if value != tags.get(t).unwrap(){
+                    return Result::Err(MemoryError::AssignmentTagInputTwice(signal_name.to_string(), t.clone()));
                 }
             }
         }
@@ -316,7 +299,7 @@ impl ComponentRepresentation {
         let inputs_response = component.inputs.get_mut(signal_name).unwrap();
         let signal_previous_value = SignalSlice::access_values(
             inputs_response,
-            &access,
+            access,
         )?;
 
         let new_value_slice = &SignalSlice::new_with_route(slice_route, &true);
@@ -324,7 +307,7 @@ impl ComponentRepresentation {
         SignalSlice::check_correct_dims(
             &signal_previous_value, 
             &Vec::new(), 
-            &new_value_slice, 
+            new_value_slice, 
             true
         )?;
 
@@ -337,8 +320,8 @@ impl ComponentRepresentation {
         
         SignalSlice::insert_values(
             inputs_response,
-            &access,
-            &new_value_slice,
+            access,
+            new_value_slice,
             true
         )?;
         let dim = SignalSlice::get_number_of_cells(new_value_slice);

--- a/constraint_generation/src/environment_utils/environment.rs
+++ b/constraint_generation/src/environment_utils/environment.rs
@@ -72,13 +72,13 @@ pub fn environment_shortcut_add_variable(
     environment.add_variable(variable_name, (TagInfo::new(), slice));
 }
 
-pub fn environment_check_all_components_assigned(environment: &ExecutionEnvironment)-> Result<(), (MemoryError, Meta)>{
+pub fn environment_check_all_components_assigned(environment: &ExecutionEnvironment)-> Result<(), Box<(MemoryError, Meta)>>{
     use program_structure::memory_slice::MemorySlice;
     for (name, slice) in environment.get_components_ref(){
         for i in 0..MemorySlice::get_number_of_cells(slice){
             let component = MemorySlice::get_reference_to_single_value_by_index_or_break(slice, i);
-            if component.is_preinitialized() && component.has_unassigned_inputs(){
-                return Result::Err((MemoryError::MissingInputs(name.clone()), component.meta.as_ref().unwrap().clone()));
+            if component.is_preinitialized() && component.has_unassigned_inputs() {
+                return Result::Err(Box::new((MemoryError::MissingInputs(name.clone()), component.meta.as_ref().unwrap().clone())));
             } 
         }
     }

--- a/constraint_generation/src/execution_data/executed_program.rs
+++ b/constraint_generation/src/execution_data/executed_program.rs
@@ -93,7 +93,7 @@ impl ExecutedProgram {
         if let Option::Some(index) = possible_index {
             return index;
         }
-        self.template_to_nodes.entry(node.template_name().clone()).or_insert_with(|| vec![]);
+        self.template_to_nodes.entry(node.template_name().clone()).or_default();
         let nodes_for_template = self.template_to_nodes.get_mut(node.template_name()).unwrap();
         let node_index = self.model.len();
         self.model.push(node);

--- a/constraint_generation/src/execution_data/executed_program.rs
+++ b/constraint_generation/src/execution_data/executed_program.rs
@@ -19,6 +19,7 @@ pub struct ExecutedProgram {
 }
 
 impl ExecutedProgram {
+    #[allow(clippy::ptr_arg)]
     pub fn new(prime: &String) -> ExecutedProgram {
         ExecutedProgram{
             model: Vec::new(),
@@ -143,12 +144,10 @@ impl ExecutedProgram {
         crate::compute_constants::manage_functions(&mut program, flags, &self.prime)?;
         crate::compute_constants::compute_vct(&mut temp_instances, &program, flags, &self.prime)?;
         let mut mixed = vec![];
-        let mut index = 0;
-        for in_mixed in mixed_instances {
+        for (index, in_mixed) in mixed_instances.into_iter().enumerate() {
             if in_mixed {
                 mixed.push(index);
             }
-            index += 1;
         }
         let config = VCPConfig {
             stats: dag_stats,

--- a/constraint_generation/src/execution_data/executed_template.rs
+++ b/constraint_generation/src/execution_data/executed_template.rs
@@ -83,6 +83,7 @@ pub struct ExecutedTemplate {
 }
 
 impl ExecutedTemplate {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         public: Vec<String>,
         name: String,
@@ -164,12 +165,12 @@ impl ExecutedTemplate {
 
     pub fn add_tag_signal(&mut self, signal_name: &str, tag_name: &str, value: Option<BigInt>){
         let tags_signal = self.signal_to_tags.get_mut(signal_name);
-        if tags_signal.is_none(){
+        if let Some(s) = tags_signal {
+            s.insert(tag_name.to_string(), value);
+        } else {
             let mut new_tags_signal = TagInfo::new();
             new_tags_signal.insert(tag_name.to_string(), value);
             self.signal_to_tags.insert(signal_name.to_string(), new_tags_signal);
-        } else {
-            tags_signal.unwrap().insert(tag_name.to_string(), value);
         }
     }
 
@@ -445,7 +446,7 @@ fn as_big_int(exprs: Vec<ArithmeticExpression<String>>) -> Vec<BigInt> {
 }
 
 fn filter_used_components(tmp: &ExecutedTemplate) -> (ComponentCollector, usize) {
-    fn compute_number_cmp(lengths: &Vec<usize>) -> usize {
+    fn compute_number_cmp(lengths: &[usize]) -> usize {
         lengths.iter().fold(1, |p, c| p * (*c))
     }
     let mut used = HashSet::with_capacity(tmp.components.len());
@@ -463,6 +464,7 @@ fn filter_used_components(tmp: &ExecutedTemplate) -> (ComponentCollector, usize)
     (filtered, number_of_components)
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Copy, Clone)]
 enum POS {
     T,
@@ -526,9 +528,7 @@ fn build_clusters(tmp: &ExecutedTemplate, instances: &[TemplateInstance]) -> Vec
         let mut end = index;
         let mut defined_positions: Vec<Vec<usize>> = vec![];
         loop {
-            if end == connexions.len() {
-                break;
-            } else if connexions[end].inspect.name != cnn_data.name {
+            if end == connexions.len() || connexions[end].inspect.name != cnn_data.name {
                 break;
             } else {
                 defined_positions.push(connexions[end].inspect.indexed_with.clone());

--- a/constraint_generation/src/execution_data/executed_template.rs
+++ b/constraint_generation/src/execution_data/executed_template.rs
@@ -293,7 +293,7 @@ impl ExecutedTemplate {
         }
         for s in &self.underscored_signals{
             let correspondence = dag.get_main().unwrap().correspondence();
-            let new_s = correspondence.get(s).unwrap().clone();
+            let new_s = *correspondence.get(s).unwrap();
             dag.add_underscored_signal(new_s);
         }
     }
@@ -457,7 +457,7 @@ fn filter_used_components(tmp: &ExecutedTemplate) -> (ComponentCollector, usize)
     for cmp in &tmp.components {
         if used.contains(&cmp.0) {
             filtered.push(cmp.clone());
-            number_of_components = number_of_components + compute_number_cmp(&cmp.1);
+            number_of_components += compute_number_cmp(&cmp.1);
         }
     }
     (filtered, number_of_components)
@@ -539,7 +539,7 @@ fn build_clusters(tmp: &ExecutedTemplate, instances: &[TemplateInstance]) -> Vec
         let cluster = TriggerCluster {
             slice: start..end,
             length: end - start,
-            defined_positions: defined_positions,
+            defined_positions,
             cmp_name: cnn_data.name.clone(),
             xtype: ClusterType::Uniform { offset_jump, component_offset_jump, instance_id, header: sub_cmp_header },
         };

--- a/constraint_generation/src/lib.rs
+++ b/constraint_generation/src/lib.rs
@@ -42,6 +42,7 @@ pub struct FlagsExecution{
 
 pub type ConstraintWriter = Box<dyn ConstraintExporter>;
 type BuildResponse = Result<(ConstraintWriter, VCP), ()>;
+#[allow(clippy::result_unit_err)]
 pub fn build_circuit(program: ProgramArchive, config: BuildConfig) -> BuildResponse {
     let files = program.file_library.clone();
     let flags = FlagsExecution{

--- a/constraint_generation/src/lib.rs
+++ b/constraint_generation/src/lib.rs
@@ -79,7 +79,7 @@ pub fn build_circuit(program: ProgramArchive, config: BuildConfig) -> BuildRespo
 
 type InstantiationResponse = Result<(ExecutedProgram, ReportCollection), ReportCollection>;
 fn instantiation(program: &ProgramArchive, flags: FlagsExecution, prime: &String) -> InstantiationResponse {
-    let execution_result = execute::constraint_execution(&program, flags, prime);
+    let execution_result = execute::constraint_execution(program, flags, prime);
     match execution_result {
         Ok((program_exe, warnings)) => {
             let no_nodes = program_exe.number_of_nodes();
@@ -93,8 +93,8 @@ fn instantiation(program: &ProgramArchive, flags: FlagsExecution, prime: &String
 }
 
 fn export(exe: ExecutedProgram, program: ProgramArchive, flags: FlagsExecution) -> ExportResult {
-    let exported = exe.export(program, flags);
-    exported
+    
+    exe.export(program, flags)
 }
 
 fn sync_dag_and_vcp(vcp: &mut VCP, dag: &mut DAG) {

--- a/constraint_list/src/constraint_simplification.rs
+++ b/constraint_list/src/constraint_simplification.rs
@@ -24,21 +24,21 @@ struct Cluster {
 impl Cluster {
     pub fn new(constraint: C, num_signals: usize) -> Cluster {
         let mut new = Cluster::default();
-        LinkedList::push_back(&mut new.constraints, constraint);
+        new.constraints.push_back(constraint);
         new.num_signals = num_signals;
         new
     }
 
     pub fn merge(mut c0: Cluster, mut c1: Cluster) -> Cluster {
         let mut result = Cluster::default();
-        LinkedList::append(&mut result.constraints, &mut c0.constraints);
-        LinkedList::append(&mut result.constraints, &mut c1.constraints);
+        result.constraints.append(&mut c0.constraints);
+        result.constraints.append(&mut c1.constraints);
         result.num_signals = c0.num_signals + c1.num_signals - 1;
         result
     }
 
     pub fn size(&self) -> usize {
-        LinkedList::len(&self.constraints)
+        self.constraints.len()
     }
 }
 
@@ -49,10 +49,10 @@ fn build_clusters(linear: LinkedList<C>, no_vars: usize) -> Vec<Cluster> {
         let mut current = org;
         let mut jumps = Vec::new();
         while current != c_to_c[current] {
-            Vec::push(&mut jumps, current);
+            jumps.push(current);
             current = c_to_c[current];
         }
-        while let Some(redirect) = Vec::pop(&mut jumps) {
+        while let Some(redirect) = jumps.pop() {
             c_to_c[redirect] = current;
         }
         current
@@ -68,16 +68,16 @@ fn build_clusters(linear: LinkedList<C>, no_vars: usize) -> Vec<Cluster> {
         c_to_c[current_src] = current_dest;
     }
 
-    let no_linear = LinkedList::len(&linear);
+    let no_linear = linear.len();
     let mut arena = ClusterArena::with_capacity(no_linear);
     let mut cluster_to_current = ClusterPath::with_capacity(no_linear);
     let mut signal_to_cluster = vec![no_linear; no_vars];
     for constraint in linear {
-        if !constraint.is_empty(){
-            let signals = C::take_cloned_signals(&constraint);
-            let dest = ClusterArena::len(&arena);
-            ClusterArena::push(&mut arena, Some(Cluster::new(constraint, signals.len())));
-            Vec::push(&mut cluster_to_current, dest);
+        if !constraint.is_empty() {
+            let signals = constraint.take_cloned_signals();
+            let dest = arena.len();
+            arena.push(Some(Cluster::new(constraint, signals.len())));
+            cluster_to_current.push(dest);
             for signal in signals {
                 let prev = signal_to_cluster[signal];
                 signal_to_cluster[signal] = dest;
@@ -88,11 +88,9 @@ fn build_clusters(linear: LinkedList<C>, no_vars: usize) -> Vec<Cluster> {
         }
     }
     let mut clusters = Vec::new();
-    for cluster in arena {
-        if let Some(cluster) = cluster {
-            if Cluster::size(&cluster) != 0 {
-                Vec::push(&mut clusters, cluster);
-            }
+    for cluster in arena.into_iter().flatten() {
+        if cluster.size() != 0 {
+            clusters.push(cluster);
         }
     }
     clusters
@@ -128,28 +126,22 @@ fn eq_cluster_simplification(
     forbidden: &HashSet<usize>,
     field: &BigInt,
 ) -> (LinkedList<S>, LinkedList<C>) {
-    if Cluster::size(&cluster) == 1 {
+    if cluster.size() == 1 {
         let mut substitutions = LinkedList::new();
         let mut constraints = LinkedList::new();
-        let constraint = LinkedList::pop_back(&mut cluster.constraints).unwrap();
-        let signals: Vec<_> = C::take_cloned_signals_ordered(&constraint).iter().cloned().collect();
+        let constraint = cluster.constraints.pop_back().unwrap();
+        let signals: Vec<_> = constraint.take_cloned_signals_ordered().iter().cloned().collect();
         let s_0 = signals[0];
         let s_1 = signals[1];
-        if HashSet::contains(forbidden, &s_0) && HashSet::contains(forbidden, &s_1) {
-            LinkedList::push_back(&mut constraints, constraint);
-        } else if HashSet::contains(forbidden, &s_0) {
-            LinkedList::push_back(
-                &mut substitutions,
-                S::new(s_1, A::Signal { symbol: s_0 }).unwrap(),
-            );
-        } else if HashSet::contains(forbidden, &s_1) {
-            LinkedList::push_back(
-                &mut substitutions,
-                S::new(s_0, A::Signal { symbol: s_1 }).unwrap(),
-            );
+        if forbidden.contains(&s_0) && forbidden.contains(&s_1) {
+            constraints.push_back(constraint);
+        } else if forbidden.contains(&s_0) {
+            substitutions.push_back(S::new(s_1, A::Signal { symbol: s_0 }).unwrap());
+        } else if forbidden.contains(&s_1) {
+            substitutions.push_back(S::new(s_0, A::Signal { symbol: s_1 }).unwrap());
         } else {
             let (l, r) = if s_0 > s_1 { (s_0, s_1) } else { (s_1, s_0) };
-            LinkedList::push_back(&mut substitutions, S::new(l, A::Signal { symbol: r }).unwrap());
+            substitutions.push_back(S::new(l, A::Signal { symbol: r }).unwrap());
         }
         (substitutions, constraints)
     } else {
@@ -158,23 +150,23 @@ fn eq_cluster_simplification(
         let (mut remains, mut min_remains) = (BTreeSet::new(), None);
         let (mut remove, mut min_remove) = (HashSet::new(), None);
         for c in cluster.constraints {
-            for signal in C::take_cloned_signals_ordered(&c) {
-                if HashSet::contains(forbidden, &signal) {
-                    BTreeSet::insert(&mut remains, signal);
+            for signal in c.take_cloned_signals_ordered() {
+                if forbidden.contains(&signal) {
+                    remains.insert(signal);
                     min_remains = Some(min_remains.map_or(signal, |s| std::cmp::min(s, signal)));
                 } else {
                     min_remove = Some(min_remove.map_or(signal, |s| std::cmp::min(s, signal)));
-                    HashSet::insert(&mut remove, signal);
+                    remove.insert(signal);
                 }
             }
         }
 
         let rh_signal = if let Some(signal) = min_remains {
-            BTreeSet::remove(&mut remains, &signal);
+            remains.remove(&signal);
             signal
         } else {
             let signal = min_remove.unwrap();
-            HashSet::remove(&mut remove, &signal);
+            remove.remove(&signal);
             signal
         };
 
@@ -183,12 +175,12 @@ fn eq_cluster_simplification(
             let r = A::Signal { symbol: rh_signal };
             let expr = A::sub(&l, &r, field);
             let c = A::transform_expression_to_constraint_form(expr, field).unwrap();
-            LinkedList::push_back(&mut cons, c);
+            cons.push_back(c);
         }
 
         for signal in remove {
             let sub = S::new(signal, A::Signal { symbol: rh_signal }).unwrap();
-            LinkedList::push_back(&mut subs, sub);
+            subs.push_back(sub);
         }
 
         (subs, cons)
@@ -210,41 +202,38 @@ fn eq_simplification(
     let clusters = build_clusters(equalities, no_vars);
     let (cluster_tx, simplified_rx) = mpsc::channel();
     let pool = ThreadPool::new(num_cpus::get());
-    let no_clusters = Vec::len(&clusters);
+    let no_clusters = clusters.len();
     // println!("Clusters: {}", no_clusters);
     let mut single_clusters = 0;
-    let mut id = 0;
     let mut aux_constraints = vec![LinkedList::new(); clusters.len()];
-    for cluster in clusters {
-        if Cluster::size(&cluster) == 1 {
+    for (id, cluster) in clusters.into_iter().enumerate() {
+        if cluster.size() == 1 {
             let (mut subs, cons) = eq_cluster_simplification(cluster, &forbidden, &field);
             aux_constraints[id] = cons;
-            LinkedList::append(&mut substitutions, &mut subs);
+            substitutions.append(&mut subs);
             single_clusters += 1;
         } else {
             let cluster_tx = cluster_tx.clone();
-            let forbidden = Arc::clone(&forbidden);
-            let field = Arc::clone(&field);
+            let forbidden = forbidden.clone();
+            let field = field.clone();
             let job = move || {
                 //println!("Cluster: {}", id);
                 let result = eq_cluster_simplification(cluster, &forbidden, &field);
                 //println!("End of cluster: {}", id);
                 cluster_tx.send((id, result)).unwrap();
             };
-            ThreadPool::execute(&pool, job);
+            pool.execute(job);
         }
-        let _ = id;
-        id += 1;
     }
     // println!("{} clusters were of size 1", single_clusters);
-    ThreadPool::join(&pool);
+    pool.join();
     for _ in 0..(no_clusters - single_clusters) {
         let (id, (mut subs, cons)) = simplified_rx.recv().unwrap();
         aux_constraints[id] = cons;
-        LinkedList::append(&mut substitutions, &mut subs);
+        substitutions.append(&mut subs);
     }
-    for id in 0..no_clusters {
-        LinkedList::append(&mut constraints, &mut aux_constraints[id]);
+    for item in aux_constraints.iter_mut().take(no_clusters) {
+        constraints.append(item);
     }
     log_substitutions(&substitutions, substitution_log);
     (substitutions, constraints)
@@ -259,13 +248,13 @@ fn constant_eq_simplification(
     let mut cons = LinkedList::new();
     let mut subs = LinkedList::new();
     for constraint in c_eq {
-        let mut signals: Vec<_> = C::take_cloned_signals_ordered(&constraint).iter().cloned().collect();
+        let mut signals: Vec<_> = constraint.take_cloned_signals_ordered().iter().cloned().collect();
         let signal = signals.pop().unwrap();
-        if HashSet::contains(forbidden, &signal) {
-            LinkedList::push_back(&mut cons, constraint);
+        if forbidden.contains(&signal) {
+            cons.push_back(constraint);
         } else {
             let sub = C::clear_signal_from_linear(constraint, &signal, field);
-            LinkedList::push_back(&mut subs, sub);
+            subs.push_back(sub);
         }
     }
     log_substitutions(&subs, substitution_log);
@@ -291,15 +280,14 @@ fn linear_simplification(
     let clusters = build_clusters(linear, no_labels);
     let (cluster_tx, simplified_rx) = mpsc::channel();
     let pool = ThreadPool::new(num_cpus::get());
-    let no_clusters = Vec::len(&clusters);
+    let no_clusters = clusters.len();
     // println!("Clusters: {}", no_clusters);
-    let mut id = 0;
     for cluster in clusters {
         let cluster_tx = cluster_tx.clone();
         let config = Config {
             field: field.clone(),
             constraints: cluster.constraints,
-            forbidden: Arc::clone(&forbidden),
+            forbidden: forbidden.clone(),
             num_signals: cluster.num_signals,
             use_old_heuristics,
         };
@@ -309,17 +297,15 @@ fn linear_simplification(
             // println!("End of cluster: {}", id);
             cluster_tx.send(result).unwrap();
         };
-        ThreadPool::execute(&pool, job);
-        let _ = id;
-        id += 1;
+        pool.execute(job);
     }
-    ThreadPool::join(&pool);
+    pool.join();
 
     for _ in 0..no_clusters {
         let mut result = simplified_rx.recv().unwrap();
         log_substitutions(&result.substitutions, log);
-        LinkedList::append(&mut cons, &mut result.constraints);
-        LinkedList::append(&mut substitutions, &mut result.substitutions);
+        cons.append(&mut result.constraints);
+        substitutions.append(&mut result.substitutions);
     }
     (substitutions, cons)
 }
@@ -329,7 +315,7 @@ fn build_non_linear_signal_map(non_linear: &ConstraintStorage) -> SignalToConstr
     let mut map = SignalToConstraints::new();
     for c_id in non_linear.get_ids() {
         let constraint = non_linear.read_constraint(c_id).unwrap();
-        for signal in C::take_cloned_signals(&constraint) {
+        for signal in constraint.take_cloned_signals() {
             if let Some(list) = map.get_mut(&signal) {
                 list.push_back(c_id);
             } else {
@@ -409,15 +395,15 @@ fn build_relevant_set(
                 None
             }
         };
-        SEncoded::get(map, &signal).and_then(f)
+        map.get(&signal).and_then(f)
     }
 
     let (_, non_linear) = EncodingIterator::take(&mut iter);
     for c in non_linear {
-        for signal in C::take_cloned_signals(&c) {
+        for signal in c.take_cloned_signals() {
             let signal = unwrapped_signal(renames, signal).unwrap_or(signal);
-            if !SEncoded::contains_key(deletes, &signal) {
-                HashSet::insert(relevant, signal);
+            if !deletes.contains_key(&signal) {
+                relevant.insert(signal);
             }
         }
     }
@@ -431,8 +417,8 @@ fn build_relevant_set(
 fn remove_not_relevant(substitutions: &mut SEncoded, relevant: &HashSet<usize>) {
     let signals: Vec<_> = substitutions.keys().cloned().collect();
     for signal in signals {
-        if !HashSet::contains(relevant, &signal) {
-            SEncoded::remove(substitutions, &signal);
+        if !relevant.contains(&signal) {
+            substitutions.remove(&signal);
         }
     }
 }
@@ -455,7 +441,7 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
     let use_old_heuristics = smp.flag_old_heuristics;
     let field = smp.field.clone();
     let forbidden = Arc::new(std::mem::replace(&mut smp.forbidden, HashSet::with_capacity(0)));
-    let no_labels = Simplifier::no_labels(smp);
+    let no_labels = smp.no_labels();
     let equalities = std::mem::take(&mut smp.equalities);
     let max_signal = smp.max_signal;
     let mut cons_equalities = std::mem::take(&mut smp.cons_equalities);
@@ -483,13 +469,13 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
         let now = SystemTime::now();
         let (subs, mut cons) = eq_simplification(
             equalities,
-            Arc::clone(&forbidden),
+            forbidden.clone(),
             no_labels,
             &field,
             &mut substitution_log,
         );
 
-        LinkedList::append(&mut lconst, &mut cons);
+        lconst.append(&mut cons);
         let mut substitutions = build_encoded_fast_substitutions(subs);
         for constraint in &mut linear {
             if fast_encoded_constraint_substitution(constraint, &substitutions, &field){
@@ -515,7 +501,7 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
         let now = SystemTime::now();
         let (subs, mut cons) =
             constant_eq_simplification(cons_equalities, &forbidden, &field, &mut substitution_log);
-        LinkedList::append(&mut lconst, &mut cons);
+        lconst.append(&mut cons);
         let substitutions = build_encoded_fast_substitutions(subs);
         for constraint in &mut linear {
             if fast_encoded_constraint_substitution(constraint, &substitutions, &field){
@@ -546,7 +532,7 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
         let (subs, mut cons) = linear_simplification(
             &mut substitution_log,
             linear,
-            Arc::clone(&forbidden),
+            forbidden.clone(),
             no_labels,
             &field,
             use_old_heuristics,
@@ -565,7 +551,7 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
         // println!("End of substitution map: {} ms", dur0);
         let _dur = now.elapsed().unwrap().as_millis();
         // println!("End of cluster simplification: {} ms", dur);
-        LinkedList::append(&mut lconst, &mut cons);
+        lconst.append(&mut cons);
         for constraint in &mut lconst {
             if fast_encoded_constraint_substitution(constraint, &substitutions, &field){
                 C::fix_constraint(constraint, &field);
@@ -573,7 +559,7 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
         }
         substitutions
     } else {
-        LinkedList::append(&mut lconst, &mut linear);
+        lconst.append(&mut linear);
         HashMap::with_capacity(0)
     };
 
@@ -581,9 +567,9 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
         // println!("Building constraint storage");
         let now = SystemTime::now();
         let mut frames = LinkedList::new();
-        LinkedList::push_back(&mut frames, single_substitutions);
-        LinkedList::push_back(&mut frames, cons_substitutions);
-        LinkedList::push_back(&mut frames, linear_substitutions);
+        frames.push_back(single_substitutions);
+        frames.push_back(cons_substitutions);
+        frames.push_back(linear_substitutions);
         let iter = EncodingIterator::new(&smp.dag_encoding);
         let mut storage = ConstraintStorage::new();
         let with_linear = obtain_and_simplify_non_linear(iter, &mut storage, &frames, &field);
@@ -614,7 +600,7 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
         let (substitutions, mut constants) = linear_simplification(
             &mut substitution_log,
             linear,
-            Arc::clone(&forbidden),
+            forbidden.clone(),
             no_labels,
             &field,
             use_old_heuristics,
@@ -645,7 +631,7 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
 
     for constraint in linear {
         if remove_unused {
-            let signals =  C::take_cloned_signals(&constraint);
+            let signals =  constraint.take_cloned_signals();
             let c_id = constraint_storage.add_constraint(constraint);
             for signal in signals {
                 if let Some(list) = non_linear_map.get_mut(&signal) {
@@ -664,7 +650,7 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
     for mut constraint in lconst {
         if remove_unused{
             C::fix_constraint(&mut constraint, &field);
-            let signals =  C::take_cloned_signals(&constraint);
+            let signals =  constraint.take_cloned_signals();
             let c_id = constraint_storage.add_constraint(constraint);
             for signal in signals {
                 if let Some(list) = non_linear_map.get_mut(&signal) {

--- a/constraint_list/src/non_linear_utils.rs
+++ b/constraint_list/src/non_linear_utils.rs
@@ -13,9 +13,9 @@ pub fn obtain_and_simplify_non_linear(
     let (_, non_linear) = EncodingIterator::take(&mut iter);
     for mut constraint in non_linear {
         for frame in frames {
-            fast_encoded_constraint_substitution(&mut constraint, frame, &field);
+            fast_encoded_constraint_substitution(&mut constraint, frame, field);
         }
-        C::fix_constraint(&mut constraint, &field);
+        C::fix_constraint(&mut constraint, field);
         if C::is_linear(&constraint) {
             linear.push_back(constraint);
         } else {

--- a/constraint_writers/src/debug_writer.rs
+++ b/constraint_writers/src/debug_writer.rs
@@ -5,10 +5,12 @@ pub struct DebugWriter {
     pub json_constraints: String,
 }
 impl DebugWriter {
+    #[allow(clippy::result_unit_err)]
     pub fn new(c: String) -> Result<DebugWriter, ()> {
         Result::Ok(DebugWriter { json_constraints: c })
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn build_constraints_file(&self) -> Result<ConstraintJSON, ()> {
         ConstraintJSON::new(&self.json_constraints)
     }

--- a/constraint_writers/src/json_writer.rs
+++ b/constraint_writers/src/json_writer.rs
@@ -7,6 +7,7 @@ pub struct ConstraintJSON {
 }
 
 impl ConstraintJSON {
+    #[allow(clippy::result_unit_err)]
     pub fn new(file: &str) -> Result<ConstraintJSON, ()> {
         let file_constraints = File::create(file).map_err(|_err| {})?;
         let mut writer_constraints = BufWriter::new(file_constraints);
@@ -18,6 +19,7 @@ impl ConstraintJSON {
 
         Result::Ok(ConstraintJSON { writer_constraints, constraints_flag: false })
     }
+    #[allow(clippy::result_unit_err)]
     pub fn write_constraint(&mut self, constraint: &str) -> Result<(), ()> {
         if !self.constraints_flag {
             self.constraints_flag = true;
@@ -31,6 +33,7 @@ impl ConstraintJSON {
         self.writer_constraints.flush().map_err(|_err| {})?;
         Result::Ok(())
     }
+    #[allow(clippy::result_unit_err)]
     pub fn end(mut self) -> Result<(), ()> {
         self.writer_constraints.write_all(b"\n]\n}").map_err(|_err| {})?;
         self.writer_constraints.flush().map_err(|_err| {})?;
@@ -42,6 +45,7 @@ pub struct SignalsJSON {
     writer_signals: BufWriter<File>,
 }
 impl SignalsJSON {
+    #[allow(clippy::result_unit_err)]
     pub fn new(file: &str) -> Result<SignalsJSON, ()> {
         let file_signals = File::create(file).map_err(|_err| {})?;
         let mut writer_signals = BufWriter::new(file_signals);
@@ -53,12 +57,14 @@ impl SignalsJSON {
         writer_signals.flush().map_err(|_err| {})?;
         Result::Ok(SignalsJSON { writer_signals })
     }
+    #[allow(clippy::result_unit_err)]
     pub fn write_correspondence(&mut self, signal: String, data: String) -> Result<(), ()> {
         self.writer_signals
             .write_all(format!(",\n\"{}\" : {}", signal, data).as_bytes())
             .map_err(|_err| {})?;
         self.writer_signals.flush().map_err(|_err| {})
     }
+    #[allow(clippy::result_unit_err)]
     pub fn end(mut self) -> Result<(), ()> {
         self.writer_signals.write_all(b"\n}\n}").map_err(|_err| {})?;
         self.writer_signals.flush().map_err(|_err| {})
@@ -70,6 +76,7 @@ pub struct SubstitutionJSON {
     first: bool,
 }
 impl SubstitutionJSON {
+    #[allow(clippy::result_unit_err)]
     pub fn new(file: &str) -> Result<SubstitutionJSON, ()> {
         let first = true;
         let file_substitutions = File::create(file).map_err(|_err| {})?;
@@ -78,6 +85,7 @@ impl SubstitutionJSON {
         writer_substitutions.flush().map_err(|_err| {})?;
         Result::Ok(SubstitutionJSON { writer_substitutions, first })
     }
+    #[allow(clippy::result_unit_err)]
     pub fn write_substitution(&mut self, signal: &str, substitution: &str) -> Result<(), ()> {
         if self.first {
             self.first = false;
@@ -91,6 +99,7 @@ impl SubstitutionJSON {
         self.writer_substitutions.flush().map_err(|_err| {})?;
         Result::Ok(())
     }
+    #[allow(clippy::result_unit_err)]
     pub fn end(mut self) -> Result<(), ()> {
         self.writer_substitutions.write_all(b"\n}").map_err(|_err| {})?;
         self.writer_substitutions.flush().map_err(|_err| {})

--- a/constraint_writers/src/lib.rs
+++ b/constraint_writers/src/lib.rs
@@ -5,7 +5,10 @@ pub mod r1cs_writer;
 pub mod sym_writer;
 
 pub trait ConstraintExporter {
+    #[allow(clippy::result_unit_err)]
     fn r1cs(&self, out: &str, custom_gates: bool) -> Result<(), ()>;
+    #[allow(clippy::result_unit_err)]
     fn json_constraints(&self, writer: &debug_writer::DebugWriter) -> Result<(), ()>;
+    #[allow(clippy::result_unit_err)]
     fn sym(&self, out: &str) -> Result<(), ()>;
 }

--- a/constraint_writers/src/log_writer.rs
+++ b/constraint_writers/src/log_writer.rs
@@ -9,6 +9,12 @@ pub struct Log {
     pub no_public_outputs: usize,
 }
 
+impl Default for Log {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Log {
     pub fn new() -> Log {
         Log {

--- a/constraint_writers/src/r1cs_writer.rs
+++ b/constraint_writers/src/r1cs_writer.rs
@@ -30,14 +30,14 @@ fn bigint_as_bytes(number: &BigInt, with_bytes: usize) -> (Vec<u8>, usize) {
 fn initialize_section(writer: &mut BufWriter<File>, header: &[u8]) -> Result<u64, ()> {
     writer.write_all(header).map_err(|_err| {})?;
     //writer.flush().map_err(|_err| {})?;
-    let go_back = writer.seek(SeekFrom::Current(0)).map_err(|_err| {})?;
+    let go_back = writer.stream_position().map_err(|_err| {})?;
     writer.write_all(PLACE_HOLDER).map_err(|_| {})?;
     //writer.flush().map_err(|_err| {})?;
     Result::Ok(go_back)
 }
 
 fn end_section(writer: &mut BufWriter<File>, go_back: u64, size: usize) -> Result<(), ()> {
-    let go_back_1 = writer.seek(SeekFrom::Current(0)).map_err(|_err| {})?;
+    let go_back_1 = writer.stream_position().map_err(|_err| {})?;
     writer.seek(SeekFrom::Start(go_back)).map_err(|_err| {})?;
     let (stream, _) = bigint_as_bytes(&BigInt::from(size), 8);
     writer.write_all(&stream).map_err(|_err| {})?;
@@ -161,7 +161,7 @@ impl R1CSWriter {
         let sections = [false; SECTIONS as usize];
         let num_sections: u8 = if custom_gates { 5 } else { 3 };
         let mut writer =
-            File::create(&output_file).map_err(|_err| {}).map(|f| BufWriter::new(f))?;
+            File::create(output_file).map_err(|_err| {}).map(BufWriter::new)?;
         initialize_file(&mut writer, num_sections)?;
         Result::Ok(R1CSWriter { writer, sections, field_size })
     }

--- a/constraint_writers/src/r1cs_writer.rs
+++ b/constraint_writers/src/r1cs_writer.rs
@@ -153,6 +153,7 @@ pub struct CustomGatesAppliedSection {
 }
 
 impl R1CSWriter {
+    #[allow(clippy::result_unit_err)]
     pub fn new(
         output_file: String,
         field_size: usize,
@@ -166,6 +167,7 @@ impl R1CSWriter {
         Result::Ok(R1CSWriter { writer, sections, field_size })
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn start_header_section(mut r1cs: R1CSWriter) -> Result<HeaderSection, ()> {
         let start = initialize_section(&mut r1cs.writer, HEADER_TYPE)?;
         Result::Ok(HeaderSection {
@@ -178,6 +180,7 @@ impl R1CSWriter {
         })
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn start_constraints_section(mut r1cs: R1CSWriter) -> Result<ConstraintSection, ()> {
         let start = initialize_section(&mut r1cs.writer, CONSTRAINT_TYPE)?;
         Result::Ok(ConstraintSection {
@@ -191,6 +194,7 @@ impl R1CSWriter {
         })
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn start_signal_section(mut r1cs: R1CSWriter) -> Result<SignalSection, ()> {
         let start = initialize_section(&mut r1cs.writer, WIRE2LABEL_TYPE)?;
         Result::Ok(SignalSection {
@@ -203,6 +207,7 @@ impl R1CSWriter {
         })
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn start_custom_gates_used_section(mut r1cs: R1CSWriter) -> Result<CustomGatesUsedSection, ()> {
         let start = initialize_section(&mut r1cs.writer, CUSTOM_GATES_USED_TYPE)?;
         Result::Ok(CustomGatesUsedSection {
@@ -215,6 +220,7 @@ impl R1CSWriter {
         })
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn start_custom_gates_applied_section(mut r1cs: R1CSWriter) -> Result<CustomGatesAppliedSection, ()> {
         let start = initialize_section(&mut r1cs.writer, CUSTOM_GATES_APPLIED_TYPE)?;
         Result::Ok(CustomGatesAppliedSection {
@@ -227,8 +233,9 @@ impl R1CSWriter {
         })
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn finish_writing(mut r1cs: R1CSWriter) -> Result<(), ()> {
-	r1cs.writer.flush().map_err(|_err| {})
+	    r1cs.writer.flush().map_err(|_err| {})
     }
 }
 
@@ -243,6 +250,7 @@ pub struct HeaderData {
 }
 
 impl HeaderSection {
+    #[allow(clippy::result_unit_err)]
     pub fn write_section(&mut self, data: HeaderData) -> Result<(), ()> {
         let (field_stream, bytes_field) = bigint_as_bytes(&data.field, self.field_size);
         let (length_stream, bytes_size) = bigint_as_bytes(&BigInt::from(self.field_size), 4);
@@ -268,6 +276,7 @@ impl HeaderSection {
         Result::Ok(())
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn end_section(mut self) -> Result<R1CSWriter, ()> {
         end_section(&mut self.writer, self.go_back, self.size)?;
         let mut sections = self.sections;
@@ -279,6 +288,7 @@ impl HeaderSection {
 
 type Constraint = HashMap<usize, BigInt>;
 impl ConstraintSection {
+    #[allow(clippy::result_unit_err)]
     pub fn write_constraint_usize(
         &mut self,
         a: &Constraint,
@@ -307,6 +317,7 @@ impl ConstraintSection {
         Result::Ok(())
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn end_section(mut self) -> Result<R1CSWriter, ()> {
         end_section(&mut self.writer, self.go_back, self.size)?;
         let mut sections = self.sections;
@@ -325,6 +336,7 @@ impl ConstraintSection {
 }
 
 impl SignalSection {
+    #[allow(clippy::result_unit_err)]
     pub fn write_signal<T>(
         &mut self,
         bytes: &T
@@ -335,11 +347,13 @@ impl SignalSection {
         //self.writer.flush().map_err(|_err| {})
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn write_signal_usize(&mut self, signal: usize) -> Result<(), ()> {
         let (_, as_bytes) = BigInt::from(signal).to_bytes_le();
         SignalSection::write_signal(self, &as_bytes)
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn end_section(mut self) -> Result<R1CSWriter, ()> {
         end_section(&mut self.writer, self.go_back, self.size)?;
         let mut sections = self.sections;
@@ -355,6 +369,7 @@ impl SignalSection {
 
 pub type CustomGatesUsedData = Vec<(String, Vec<BigInt>)>;
 impl CustomGatesUsedSection {
+    #[allow(clippy::result_unit_err)]
     pub fn write_custom_gates_usages(&mut self, data: CustomGatesUsedData) -> Result<(), ()> {
         let no_custom_gates = data.len();
         let (no_custom_gates_stream, no_custom_gates_size) =
@@ -390,6 +405,7 @@ impl CustomGatesUsedSection {
         Result::Ok(())
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn end_section(mut self) -> Result<R1CSWriter, ()> {
         end_section(&mut self.writer, self.go_back, self.size)?;
         let mut sections = self.sections;
@@ -405,6 +421,7 @@ impl CustomGatesUsedSection {
 
 pub type CustomGatesAppliedData = Vec<(usize, Vec<usize>)>;
 impl CustomGatesAppliedSection {
+    #[allow(clippy::result_unit_err)]
     pub fn write_custom_gates_applications(&mut self, data: CustomGatesAppliedData) -> Result<(), ()> {
         let no_custom_gate_applications = data.len();
         let (no_custom_gate_applications_stream, no_custom_gate_applications_size) =
@@ -440,6 +457,7 @@ impl CustomGatesAppliedSection {
         Result::Ok(())
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn end_section(mut self) -> Result<R1CSWriter, ()> {
         end_section(&mut self.writer, self.go_back, self.size)?;
         let mut sections = self.sections;

--- a/constraint_writers/src/sym_writer.rs
+++ b/constraint_writers/src/sym_writer.rs
@@ -18,20 +18,23 @@ pub struct SymFile {
 }
 
 impl SymFile {
+    #[allow(clippy::result_unit_err)]
     pub fn new(file: &str) -> Result<SymFile, ()> {
         let file = File::create(file).map_err(|_err| {})?;
         let writer = BufWriter::new(file);
         Result::Ok(SymFile { writer })
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn write_sym_elem(sym: &mut SymFile, elem: SymElem) -> Result<(), ()> {
         sym.writer.write_all(elem.to_string().as_bytes()).map_err(|_err| {})?;
         sym.writer.write_all(b"\n").map_err(|_err| {}) //?;
         //sym.writer.flush().map_err(|_err| {})
     }
     
+    #[allow(clippy::result_unit_err)]
     pub fn finish_writing(mut sym: SymFile) -> Result<(), ()> {
-	sym.writer.flush().map_err(|_err| {})
+	    sym.writer.flush().map_err(|_err| {})
     }
 
     // pub fn close(_sym: SymFile) {}

--- a/dag/src/constraint_correctness_analysis.rs
+++ b/dag/src/constraint_correctness_analysis.rs
@@ -16,8 +16,8 @@ impl UnconstrainedSignal {
         
         if examples.len() == 1{
             let msg = format!("In template \"{}\": Local signal {} does not appear in any constraint", template, examples[0]);
-            let report = Report::warning(msg, UNCONSTRAINED_SIGNAL_CODE);
-            report
+            
+            Report::warning(msg, UNCONSTRAINED_SIGNAL_CODE)
         } else{
             let msg = format!("In template \"{}\": Array of local signals {} contains a total of {} signals that do not appear in any constraint", template, signal, examples.len());
             let mut report = Report::warning(msg, UNCONSTRAINED_SIGNAL_CODE);
@@ -34,8 +34,8 @@ impl UnconstrainedIOSignal {
         
         if examples.len() == 1{
             let msg = format!("In template \"{}\": Subcomponent input/output signal {} does not appear in any constraint of the father component", template, examples[0]);
-            let report = Report::warning(msg, UNCONSTRAINED_IOSIGNAL_CODE);
-            report
+            
+            Report::warning(msg, UNCONSTRAINED_IOSIGNAL_CODE)
         } else{
             let msg = format!("In template \"{}\": Array of subcomponent input/output signals {} contains a total of {} signals that do not appear in any constraint of the father component", template, signal, examples.len());
             let mut report = Report::warning(msg, UNCONSTRAINED_IOSIGNAL_CODE);
@@ -58,7 +58,7 @@ struct Analysis {
 }
 
 fn split_signal_name_index(name: &String)-> String{
-    let split_components:Vec<&str> = name.split(".").collect(); // split the name of components
+    let split_components:Vec<&str> = name.split('.').collect(); // split the name of components
     let mut signal_name = "".to_string();
     for i in 0..split_components.len()-1{
         signal_name = signal_name + split_components[i] + "."; // take the index of the components
@@ -66,7 +66,7 @@ fn split_signal_name_index(name: &String)-> String{
     // no take the index of the array position
     let aux_last_component = split_components[split_components.len()-1].to_string();
     let split_index_last_component = 
-        aux_last_component.split("[").next().unwrap(); 
+        aux_last_component.split('[').next().unwrap(); 
     signal_name + split_index_last_component
 }
 
@@ -118,7 +118,7 @@ fn visit_node(node: &Node) -> Analysis {
     }
 
     for signal in &node.underscored_signals{
-        let prev = constraint_counter.remove(&signal).unwrap();
+        let prev = constraint_counter.remove(signal).unwrap();
         constraint_counter.insert(*signal, prev + 1);
     }
 

--- a/dag/src/constraint_correctness_analysis.rs
+++ b/dag/src/constraint_correctness_analysis.rs
@@ -12,17 +12,14 @@ const UNCONSTRAINED_IOSIGNAL_CODE: ReportCode = ReportCode::UnconstrainedIOSigna
 
 struct UnconstrainedSignal;
 impl UnconstrainedSignal {
-    pub fn new(signal: &str, template: &str, examples: &Vec<String>) -> Report {
-        
+    pub fn report(signal: &str, template: &str, examples: &Vec<String>) -> Report {
         if examples.len() == 1{
             let msg = format!("In template \"{}\": Local signal {} does not appear in any constraint", template, examples[0]);
-            
             Report::warning(msg, UNCONSTRAINED_SIGNAL_CODE)
         } else{
             let msg = format!("In template \"{}\": Array of local signals {} contains a total of {} signals that do not appear in any constraint", template, signal, examples.len());
             let mut report = Report::warning(msg, UNCONSTRAINED_SIGNAL_CODE);
-            let ex = format!("For example: {}, {}.", examples[0], examples[1]);
-            report.add_note(ex);
+            report.add_note(format!("For example: {}, {}.", examples[0], examples[1]));
             report
         }
     }
@@ -30,17 +27,14 @@ impl UnconstrainedSignal {
 
 struct UnconstrainedIOSignal;
 impl UnconstrainedIOSignal {
-    pub fn new(signal: &str, template: &str, examples: &Vec<String>) -> Report {
-        
+    pub fn report(signal: &str, template: &str, examples: &Vec<String>) -> Report {
         if examples.len() == 1{
             let msg = format!("In template \"{}\": Subcomponent input/output signal {} does not appear in any constraint of the father component", template, examples[0]);
-            
             Report::warning(msg, UNCONSTRAINED_IOSIGNAL_CODE)
         } else{
             let msg = format!("In template \"{}\": Array of subcomponent input/output signals {} contains a total of {} signals that do not appear in any constraint of the father component", template, signal, examples.len());
             let mut report = Report::warning(msg, UNCONSTRAINED_IOSIGNAL_CODE);
-            let ex = format!("For example: {}, {}.", examples[0], examples[1]);
-            report.add_note(ex);
+            report.add_note(format!("For example: {}, {}.", examples[0], examples[1]));
             report
         }
     }
@@ -57,16 +51,15 @@ struct Analysis {
     signal_stats: Vec<(String, SignalType, usize)>,
 }
 
-fn split_signal_name_index(name: &String)-> String{
-    let split_components:Vec<&str> = name.split('.').collect(); // split the name of components
+fn split_signal_name_index(name: &str) -> String {
+    let split_components: Vec<&str> = name.split('.').collect(); // split the name of components
     let mut signal_name = "".to_string();
-    for i in 0..split_components.len()-1{
-        signal_name = signal_name + split_components[i] + "."; // take the index of the components
+    for item in split_components.iter().take(split_components.len() - 1) {
+        signal_name = signal_name + item + "."; // take the index of the components
     }
     // no take the index of the array position
-    let aux_last_component = split_components[split_components.len()-1].to_string();
-    let split_index_last_component = 
-        aux_last_component.split('[').next().unwrap(); 
+    let aux_last_component = split_components[split_components.len() - 1].to_string();
+    let split_index_last_component = aux_last_component.split('[').next().unwrap();
     signal_name + split_index_last_component
 }
 
@@ -92,9 +85,9 @@ fn analysis_interpretation(analysis: Analysis, result: &mut AnalysisResult) {
     }
     for (name, (xtype, examples)) in signal2unconstrainedex{
         if xtype == SignalType::Local{
-            result.warnings.push(UnconstrainedSignal::new(&name, &tmp_name, &examples));
+            result.warnings.push(UnconstrainedSignal::report(&name, &tmp_name, &examples));
         } else{
-            result.warnings.push(UnconstrainedIOSignal::new(&name, &tmp_name, &examples));
+            result.warnings.push(UnconstrainedIOSignal::report(&name, &tmp_name, &examples));
         }
     }
 }

--- a/dag/src/json_porting.rs
+++ b/dag/src/json_porting.rs
@@ -29,7 +29,7 @@ fn hashmap_as_json(values: &HashMap<usize, BigInt>) -> JsonValue {
 
 fn visit_tree(tree: &Tree, writer: &mut ConstraintJSON) -> Result<(), ()> {
     for constraint in &tree.constraints {
-        let json_value = transform_constraint_to_json(&constraint);
+        let json_value = transform_constraint_to_json(constraint);
         writer.write_constraint(&json_value.to_string())?;
     }
     for edge in Tree::get_edges(tree) {

--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -314,9 +314,9 @@ impl ConstraintExporter for DAG {
 }
 
 impl DAG {
-    pub fn new(prime: &String) -> DAG {
-        DAG{
-            prime : prime.clone(),
+    pub fn new(prime: &str) -> DAG {
+        DAG {
+            prime : prime.to_owned(),
             one_signal: 0,
             nodes: Vec::new(),
             adjacency: Vec::new(),
@@ -471,14 +471,17 @@ impl DAG {
         constraint_correctness_analysis::clean_constraints(&mut self.nodes);
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn generate_r1cs_output(&self, output_file: &str, custom_gates: bool) -> Result<(), ()> {
         r1cs_porting::write(self, output_file, custom_gates)
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn generate_sym_output(&self, output_file: &str) -> Result<(), ()> {
         sym_porting::write(self, output_file)
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn generate_json_constraints(&self, debug: &DebugWriter) -> Result<(), ()> {
         json_porting::port_constraints(self, debug)
     }

--- a/parser/src/include_logic.rs
+++ b/parser/src/include_logic.rs
@@ -92,7 +92,7 @@ impl IncludesGraph {
         crr.push(old_path.clone());
         let path = std::fs::canonicalize(crr)
             .map_err(|_e| produce_report_with_message(ReportCode::FileOs, old_path))?;
-        let edges = self.adjacency.entry(path).or_insert(vec![]);
+        let edges = self.adjacency.entry(path).or_default();
         edges.push(self.nodes.len() - 1);
         Ok(())
     }
@@ -149,7 +149,7 @@ impl IncludesGraph {
         let mut sep = "";
         for file in path.iter().map(|file| file.display().to_string()) {
             res.push_str(sep);
-            let result_split = file.rsplit_once("/");
+            let result_split = file.rsplit_once('/');
             if result_split.is_some(){
                 res.push_str(result_split.unwrap().1);
             } else{

--- a/parser/src/include_logic.rs
+++ b/parser/src/include_logic.rs
@@ -17,6 +17,7 @@ impl FileStack {
         FileStack { current_location: location, black_paths: HashSet::new(), stack: vec![src] }
     }
 
+    #[allow(clippy::ptr_arg, clippy::result_large_err)]
     pub fn add_include(
         f_stack: &mut FileStack,
         name: String,
@@ -87,6 +88,7 @@ impl IncludesGraph {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     pub fn add_edge(&mut self, old_path: String) -> Result<(), Report> {
         let mut crr = PathBuf::new();
         crr.push(old_path.clone());
@@ -144,15 +146,15 @@ impl IncludesGraph {
         problematic_paths
     }
 
+    #[allow(clippy::ptr_arg)]
     pub fn display_path(path: &Vec<PathBuf>) -> String {
         let mut res = String::new();
         let mut sep = "";
         for file in path.iter().map(|file| file.display().to_string()) {
             res.push_str(sep);
-            let result_split = file.rsplit_once('/');
-            if result_split.is_some(){
-                res.push_str(result_split.unwrap().1);
-            } else{
+            if let Some((_, s)) = file.rsplit_once('/') {
+                res.push_str(s);
+            } else {
                 res.push_str(&file);
             }
             sep = " -> ";

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -49,7 +49,7 @@ pub fn find_file(
             }
             Err(e) => {
                 reports.push(e);
-                i = i + 1;
+                i += 1;
             }
         }
     }
@@ -109,7 +109,7 @@ pub fn run_parser(
         }
     }
 
-    if main_components.len() == 0 {
+    if main_components.is_empty() {
         let report = produce_report(ReportCode::NoMainFoundInProject,0..0, 0);
         warnings.push(report);
         Err((file_library, warnings))
@@ -128,7 +128,7 @@ pub fn run_parser(
                 ReportCode::CustomGatesPragmaError
             )
         ).collect();
-        if errors.len() > 0 {
+        if !errors.is_empty() {
             warnings.append(& mut errors);
             Err((file_library, warnings))
         } else {
@@ -184,7 +184,7 @@ fn open_file(path: PathBuf) -> Result<(String, String), Report> /* path, src */ 
 }
 
 fn parse_number_version(version: &str) -> Version {
-    let version_splitted: Vec<&str> = version.split(".").collect();
+    let version_splitted: Vec<&str> = version.split('.').collect();
     (
         usize::from_str(version_splitted[0]).unwrap(),
         usize::from_str(version_splitted[1]).unwrap(),
@@ -239,25 +239,23 @@ fn check_custom_gates_version(
             );
             return Err(report);
         }
-    } else {
-        if version_compiler.0 < custom_gates_version.0
-            || (version_compiler.0 == custom_gates_version.0
-                && version_compiler.1 < custom_gates_version.1)
-            || (version_compiler.0 == custom_gates_version.0
-                && version_compiler.1 == custom_gates_version.1
-                && version_compiler.2 < custom_gates_version.2)
-        {
-            let report = Report::error(
-                format!(
-                    "File {} does not include pragma version and the compiler version (currently {:?}) should be at least {:?} to use custom templates",
-                    file_path,
-                    version_compiler,
-                    custom_gates_version
-                ),
-                ReportCode::CustomGatesVersionError
-            );
-            return Err(report);
-        }
+    } else if version_compiler.0 < custom_gates_version.0
+        || (version_compiler.0 == custom_gates_version.0
+            && version_compiler.1 < custom_gates_version.1)
+        || (version_compiler.0 == custom_gates_version.0
+            && version_compiler.1 == custom_gates_version.1
+            && version_compiler.2 < custom_gates_version.2)
+    {
+        let report = Report::error(
+            format!(
+                "File {} does not include pragma version and the compiler version (currently {:?}) should be at least {:?} to use custom templates",
+                file_path,
+                version_compiler,
+                custom_gates_version
+            ),
+            ReportCode::CustomGatesVersionError
+        );
+        return Err(report);
     }
     Ok(())
 }

--- a/parser/src/parser_logic.rs
+++ b/parser/src/parser_logic.rs
@@ -1,5 +1,5 @@
 use super::lang;
-use program_structure::ast::{AST};
+use program_structure::ast::AST;
 use program_structure::ast::produce_report;
 use program_structure::error_code::ReportCode;
 use program_structure::error_definition::{ReportCollection, Report};

--- a/parser/src/syntax_sugar_remover.rs
+++ b/parser/src/syntax_sugar_remover.rs
@@ -9,19 +9,17 @@ use program_structure::template_data::TemplateData;
 use std::collections::{HashMap, BTreeMap};
 use num_bigint::BigInt;
 
-
-
-pub fn apply_syntactic_sugar(program_archive : &mut  ProgramArchive) -> Result<(), Report> {
+pub fn apply_syntactic_sugar(program_archive: &mut  ProgramArchive) -> Result<(), Box<Report>> {
     if program_archive.get_main_expression().is_anonymous_comp() {
-        return Result::Err(anonymous_general_error(program_archive.get_main_expression().get_meta().clone(),"The main component cannot contain an anonymous call  ".to_string()));
-     
+        return Result::Err(Box::new(anonymous_general_error(program_archive.get_main_expression().get_meta().clone(), "The main component cannot contain an anonymous call  ".to_string())));
     }
-    let old_templates = program_archive.templates.clone();
 
-    for (_name, t) in &mut program_archive.templates {
+    let old_templates = program_archive.templates.clone();
+    for t in program_archive.templates.values_mut() {
         let old_body = t.get_body().clone();
         check_anonymous_components_statement(&old_body)?;
-        let (new_body, component_decs, variable_decs, mut substitutions) = remove_anonymous_from_statement(&old_templates, &program_archive.file_library, old_body, &None)?;
+        let (new_body, component_decs, variable_decs, mut substitutions) 
+            = remove_anonymous_from_statement(&old_templates, &program_archive.file_library, old_body, &None)?;
         if let Statement::Block { meta, mut stmts } = new_body {
             let mut init_block = vec![
                 build_initialization_block(meta.clone(), VariableType::Var, variable_decs),
@@ -32,17 +30,16 @@ pub fn apply_syntactic_sugar(program_archive : &mut  ProgramArchive) -> Result<(
             check_tuples_statement(&new_body_with_inits)?;
             let new_body = remove_tuples_from_statement(new_body_with_inits)?;
             t.set_body(new_body);
-        } else{
+        } else {
             unreachable!()
         }
     }
 
-
-    for (_, t) in &mut program_archive.functions {
+    for t in program_archive.functions.values_mut() {
         let old_body = t.get_body().clone();
-        if old_body.contains_anonymous_comp(){
-            return Result::Err(anonymous_general_error(old_body.get_meta().clone(),"Functions cannot contain calls to anonymous templates".to_string()));
-        } else{
+        if old_body.contains_anonymous_comp() {
+            return Result::Err(Box::new(anonymous_general_error(old_body.get_meta().clone(), "Functions cannot contain calls to anonymous templates".to_string())));
+        } else {
             check_tuples_statement(&old_body)?;
             let new_body = remove_tuples_from_statement(old_body)?;
             t.set_body(new_body);
@@ -51,40 +48,36 @@ pub fn apply_syntactic_sugar(program_archive : &mut  ProgramArchive) -> Result<(
     Result::Ok(())
 }
 
-
-fn check_anonymous_components_statement(
-    stm : &Statement,
-) -> Result<(), Report>{
+fn check_anonymous_components_statement(stm: &Statement) -> Result<(), Box<Report>> {
     match stm {
         Statement::MultSubstitution {meta, lhe, rhe,  op, ..} => {
             if lhe.contains_anonymous_comp() {
-                Result::Err(anonymous_general_error(
+                Result::Err(Box::new(anonymous_general_error(
                     meta.clone(),
                     "An anonymous component cannot be used in the left side of an assignment".to_string())
-                )
-            } else if rhe.contains_anonymous_comp() && *op == AssignOp::AssignSignal{
+                ))
+            } else if rhe.contains_anonymous_comp() && *op == AssignOp::AssignSignal {
                 let error = "Anonymous components only admit the use of the operator <==".to_string();
-                Result::Err(anonymous_general_error(meta.clone(),error))
-            } else{
+                Result::Err(Box::new(anonymous_general_error(meta.clone(), error)))
+            } else {
                 check_anonymous_components_expression(rhe)
             }
         },
-        Statement::IfThenElse { meta, cond, if_case, else_case, .. } 
-        => { 
+        Statement::IfThenElse { meta, cond, if_case, else_case, .. } => { 
             if cond.contains_anonymous_comp() {
-                Result::Err(anonymous_inside_condition_error(meta.clone()))
-            } else{
+                Result::Err(Box::new(anonymous_inside_condition_error(meta.clone())))
+            } else {
                 check_anonymous_components_statement(if_case)?;
-                if else_case.is_some(){
-                    check_anonymous_components_statement(else_case.as_ref().unwrap())?;
+                if let Some(stm) = else_case {
+                    check_anonymous_components_statement(stm)?;
                 }
                 Result::Ok(())
             }
         }
-        Statement::While { meta, cond, stmt, .. }   => {
+        Statement::While { meta, cond, stmt, .. } => {
             if cond.contains_anonymous_comp() {
-                Result::Err(anonymous_inside_condition_error(meta.clone()))
-            } else{
+                Result::Err(Box::new(anonymous_inside_condition_error(meta.clone())))
+            } else {
                 check_anonymous_components_statement(stmt)
             }
         }     
@@ -92,51 +85,48 @@ fn check_anonymous_components_statement(
             for arg in args {
                 if let program_structure::ast::LogArgument::LogExp( exp ) = arg {
                     if exp.contains_anonymous_comp() {
-                        return Result::Err(anonymous_general_error(meta.clone() ,"An anonymous component cannot be used inside a log".to_string()))
+                        return Result::Err(Box::new(anonymous_general_error(meta.clone() , "An anonymous component cannot be used inside a log".to_string())))
                     }
                 }
             }
             Result::Ok(())
         }  
-        Statement::Assert { meta, arg}   => {
+        Statement::Assert { meta, arg} => {
             if arg.contains_anonymous_comp() {
-                Result::Err(anonymous_general_error(meta.clone(), "An anonymous component cannot be used inside an assert".to_string()))
-            } else{
+                Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used inside an assert".to_string())))
+            } else {
                 Result::Ok(())
             }
         }
         Statement::Return {  meta, value: arg}=> {
-            if arg.contains_anonymous_comp(){
-                Result::Err(anonymous_general_error(meta.clone(), "An anonymous component cannot be used inside a function ".to_string()))
-            } else{
+            if arg.contains_anonymous_comp() {
+                Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used inside a function ".to_string())))
+            } else {
                 Result::Ok(())
             }
         }
         Statement::ConstraintEquality {meta, lhe, rhe } => {
             if lhe.contains_anonymous_comp() || rhe.contains_anonymous_comp() {
-                Result::Err(anonymous_general_error(meta.clone(), "An anonymous component cannot be used with operator === ".to_string()))
-            }
-            else{
+                Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used with operator === ".to_string())))
+            } else {
                 Result::Ok(()) 
             }
         }
         Statement::Declaration { meta, dimensions, .. } => {
-            for exp in dimensions{
-                if exp.contains_anonymous_comp(){
-                    return Result::Err(anonymous_general_error(meta.clone(),"An anonymous component cannot be used to define a dimension of an array".to_string()));
+            for exp in dimensions {
+                if exp.contains_anonymous_comp() {
+                    return Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used to define a dimension of an array".to_string())));
                 }
             }
             Result::Ok(())
         }
-        Statement::InitializationBlock { initializations, .. } =>
-        {
+        Statement::InitializationBlock { initializations, .. } => {
             for stmt in initializations {
                 check_anonymous_components_statement(stmt)?;
             }
             Result::Ok(())
         }
-        Statement::Block {stmts, .. } => { 
-
+        Statement::Block {stmts, .. } => {
             for stmt in stmts {
                 check_anonymous_components_statement(stmt)?;
             }
@@ -145,21 +135,21 @@ fn check_anonymous_components_statement(
         Statement::Substitution { meta, rhe, access, op, ..} => {
             use program_structure::ast::Access::ComponentAccess;
             use program_structure::ast::Access::ArrayAccess;
-            for acc in access{
-                match acc{
-                    ArrayAccess(exp) =>{
-                        if exp.contains_anonymous_comp(){
-                            return Result::Err(anonymous_general_error(meta.clone(),"An anonymous component cannot be used to define a dimension of an array".to_string()));
+            for acc in access {
+                match acc {
+                    ArrayAccess(exp) => {
+                        if exp.contains_anonymous_comp() {
+                            return Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used to define a dimension of an array".to_string())));
                         }
                     },
-                    ComponentAccess(_)=>{},
+                    ComponentAccess(_) => {},
                 }
             }
 
-            if rhe.contains_anonymous_comp() && *op == AssignOp::AssignSignal{
+            if rhe.contains_anonymous_comp() && *op == AssignOp::AssignSignal {
                 let error = "Anonymous components only admit the use of the operator <==".to_string();
-                Result::Err(anonymous_general_error(meta.clone(),error))
-            } else{
+                Result::Err(Box::new(anonymous_general_error(meta.clone(), error)))
+            } else {
                 check_anonymous_components_expression(rhe)
             }
         }
@@ -167,23 +157,21 @@ fn check_anonymous_components_statement(
     }
 }
 
-pub fn check_anonymous_components_expression(
-    exp : &Expression,
-) -> Result<(),Report>{
+pub fn check_anonymous_components_expression(exp: &Expression) -> Result<(), Box<Report>> {
     use Expression::*;
     match exp {
         ArrayInLine { meta, values, .. } => {    
             for value in values{
                 if value.contains_anonymous_comp() {
-                    return Result::Err(anonymous_general_error(meta.clone(),"An anonymous component cannot be used to define a dimension of an array".to_string()));
+                    return Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used to define a dimension of an array".to_string())));
                 }
             }
             Result::Ok(())
         }, 
         UniformArray { meta, value, dimension } => {
             if value.contains_anonymous_comp() || dimension.contains_anonymous_comp() {
-                Result::Err(anonymous_general_error(meta.clone(),"An anonymous component cannot be used to define a dimension of an array".to_string()))
-            } else{
+                Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used to define a dimension of an array".to_string())))
+            } else {
                 Result::Ok(())
             }
         },
@@ -193,77 +181,76 @@ pub fn check_anonymous_components_expression(
         Variable { meta, access, .. } => {
             use program_structure::ast::Access::ComponentAccess;
             use program_structure::ast::Access::ArrayAccess;
-            for acc in access{
-                match acc{
-                    ArrayAccess(exp) =>{
-                        if exp.contains_anonymous_comp(){
-                            return Result::Err(anonymous_general_error(meta.clone(),"An anonymous component cannot be used to define a dimension of an array".to_string()));
+            for acc in access {
+                match acc {
+                    ArrayAccess(exp) => {
+                        if exp.contains_anonymous_comp() {
+                            return Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used to define a dimension of an array".to_string())));
                         }
                     },
-                    ComponentAccess(_)=>{},
+                    ComponentAccess(_) => {},
                 }
             }
             Result::Ok(())
         },
         InfixOp { meta, lhe, rhe, .. } => {
             if lhe.contains_anonymous_comp() || rhe.contains_anonymous_comp() {
-                Result::Err(anonymous_general_error(meta.clone(),"An anonymous component cannot be used in the middle of an operation ".to_string()))
-            } else{
+                Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used in the middle of an operation ".to_string())))
+            } else {
                 Result::Ok(())
             }
         },
         PrefixOp { meta, rhe, .. } => {
-            if rhe.contains_anonymous_comp()  {
-                Result::Err(anonymous_general_error(meta.clone(),"An anonymous component cannot be used in the middle of an operation ".to_string()))
-            } else{
+            if rhe.contains_anonymous_comp() {
+                Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used in the middle of an operation ".to_string())))
+            } else {
                 Result::Ok(())
             }
         },
-        InlineSwitchOp { meta, cond, if_true,  if_false } => {
+        InlineSwitchOp { meta, cond, if_true, if_false } => {
             if cond.contains_anonymous_comp() || if_true.contains_anonymous_comp() || if_false.contains_anonymous_comp() {
-                Result::Err(anonymous_general_error(meta.clone(),"An anonymous component cannot be used inside an inline switch ".to_string()))
-            } else{
+                Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used inside an inline switch ".to_string())))
+            } else {
                 Result::Ok(())
             }
         },
         Call { meta, args, .. } => {
-            for value in args{
+            for value in args {
                 if value.contains_anonymous_comp() {
-                    return Result::Err(anonymous_general_error(meta.clone(),"An anonymous component cannot be used as a parameter in a template call ".to_string()));
+                    return Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used as a parameter in a template call ".to_string())));
                 }
             }
             Result::Ok(())
         },
         AnonymousComp {meta, params, signals, .. } => {
-            for value in params{
+            for value in params {
                 if value.contains_anonymous_comp() {
-                    return Result::Err(anonymous_general_error(meta.clone(),"An anonymous component cannot be used as a parameter in a template call ".to_string()));
+                    return Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used as a parameter in a template call ".to_string())));
                 }
             }
-            for value in signals{
+            for value in signals {
                 check_anonymous_components_expression(value)?;
             }
             Result::Ok(())
         },
         Tuple {values, .. } => {
-
             for val in values{
                 check_anonymous_components_expression(val)?;
             }
             Result::Ok(())
         },
         ParallelOp { meta, rhe } => {
-            if !rhe.is_call() && !rhe.is_anonymous_comp() && rhe.contains_anonymous_comp() {
-                return Result::Err(anonymous_general_error(meta.clone(),"Bad use of parallel operator in combination with anonymous components ".to_string()));       
-            }
-            else if rhe.is_call() && rhe.contains_anonymous_comp() {
-                return Result::Err(anonymous_general_error(meta.clone(),"An anonymous component cannot be used as a parameter in a template call ".to_string()));
+            if rhe.contains_anonymous_comp() {
+                if rhe.is_call() {
+                    return Result::Err(Box::new(anonymous_general_error(meta.clone(), "An anonymous component cannot be used as a parameter in a template call ".to_string())));
+                } else if !rhe.is_anonymous_comp() {
+                    return Result::Err(Box::new(anonymous_general_error(meta.clone(), "Bad use of parallel operator in combination with anonymous components ".to_string())));       
+                }
             }
             Result::Ok(())
         },
     }
 }
-
 
 // (Body, init_components, init_variables, substitutions)
 pub type UpdatedStatement = (Statement, Vec<Statement>, Vec<Statement>, Vec<Statement>);
@@ -272,47 +259,46 @@ pub type UpdatedStatement = (Statement, Vec<Statement>, Vec<Statement>, Vec<Stat
 pub type UpdatedExpression = (Vec<Statement>, Vec<Statement>, Expression);
 
 fn remove_anonymous_from_statement(
-    templates : &HashMap<String, TemplateData>, 
-    file_lib : &FileLibrary,  
-    stm : Statement,
-    var_access: &Option<Expression>
-) -> Result< UpdatedStatement, Report>{
+    templates: &HashMap<String, TemplateData>,
+    file_lib: &FileLibrary,
+    stm: Statement,
+    var_access: &Option<Expression>,
+) -> Result< UpdatedStatement, Box<Report>>{
     match stm {
         Statement::MultSubstitution { meta, lhe, op, rhe } => {
-
-            let (comp_declarations, mut substitutions, new_rhe) = remove_anonymous_from_expression(templates, file_lib, rhe, var_access)?;
+            let (comp_declarations, mut substitutions, new_rhe)
+                = remove_anonymous_from_expression(templates, file_lib, rhe, var_access)?;
             let subs = Statement::MultSubstitution { meta: meta.clone(), lhe, op, rhe: new_rhe };
-            if substitutions.is_empty(){
+            if substitutions.is_empty() {
                 Result::Ok((subs, comp_declarations, Vec::new(), Vec::new()))
-            }else{
+            } else {
                 substitutions.push(subs);
-                Result::Ok((Statement::Block { meta, stmts : substitutions}, comp_declarations, Vec::new(), Vec::new()))   
+                Result::Ok((Statement::Block { meta, stmts: substitutions}, comp_declarations, Vec::new(), Vec::new()))   
             }
         },
-        Statement::IfThenElse { meta, cond, if_case, else_case } 
-        => { 
-
-            let (if_body, mut if_comp_dec, mut if_var_dec, mut if_subs) = remove_anonymous_from_statement(templates, file_lib, *if_case, var_access)?;
-            let b_if = Box::new(if_body);
-            if else_case.is_none(){
-                Result::Ok((Statement::IfThenElse { meta, cond, if_case: b_if, else_case: Option::None}, if_comp_dec, if_var_dec, if_subs))
-            }else {
-                let else_c = *(else_case.unwrap());
-                let (else_body, mut else_comp_dec, mut else_var_dec, mut else_subs) = remove_anonymous_from_statement(templates, file_lib, else_c, var_access)?;
-                let b_else = Box::new(else_body);
+        Statement::IfThenElse { meta, cond, if_case, else_case } => { 
+            let (if_body, mut if_comp_dec, mut if_var_dec, mut if_subs)
+                = remove_anonymous_from_statement(templates, file_lib, *if_case, var_access)?;
+            let b_else = if let Some(else_c) = else_case {
+                let (else_body, mut else_comp_dec, mut else_var_dec, mut else_subs)
+                    = remove_anonymous_from_statement(templates, file_lib, *else_c, var_access)?;
                 if_comp_dec.append(&mut else_comp_dec);
                 if_var_dec.append(&mut else_var_dec);
                 if_subs.append(&mut else_subs);
-                Result::Ok((Statement::IfThenElse { meta, cond, if_case: b_if, else_case: Option::Some(b_else)}, if_comp_dec, if_var_dec, if_subs))
-            }
+                Option::Some(Box::new(else_body))
+            } else {
+                Option::None
+            };
+            Result::Ok((Statement::IfThenElse { meta, cond, if_case: Box::new(if_body), else_case: b_else}, if_comp_dec, if_var_dec, if_subs))
         }
-        Statement::While { meta, cond, stmt }   => {
+        Statement::While { meta, cond, stmt } => {
             let id_var_while = "anon_var_".to_string() + &file_lib.get_line(meta.start, meta.get_file_id()).unwrap().to_string() + "_" + &meta.start.to_string();
-            let var_access = Expression::Variable{meta: meta.clone(), name: id_var_while.clone(), access: Vec::new()};
+            let var_access = Expression::Variable{ meta: meta.clone(), name: id_var_while.clone(), access: Vec::new() };
             let mut var_declarations = vec![];
             let mut subs_out = vec![];
-            let (body, comp_dec, mut var_dec, mut subs) = remove_anonymous_from_statement(templates, file_lib, *stmt, &Some(var_access.clone()))?;
-            let b_while = if !comp_dec.is_empty(){
+            let (body, comp_dec, mut var_dec, mut subs)
+                = remove_anonymous_from_statement(templates, file_lib, *stmt, &Some(var_access.clone()))?;
+            let b_while = if !comp_dec.is_empty() {
                 var_declarations.push(
                     build_declaration(
                         meta.clone(), 
@@ -332,40 +318,38 @@ fn remove_anonymous_from_statement(
                 );
                 var_declarations.append(&mut var_dec);
                 subs_out.append(&mut subs);
-                let next_access = Expression::InfixOp{
+                let next_access = Expression::InfixOp {
                     meta: meta.clone(),
                     infix_op: ExpressionInfixOpcode::Add,
                     lhe: Box::new(var_access),
-                    rhe: Box::new(Expression::Number(meta.clone(),  BigInt::from(1))),
+                    rhe: Box::new(Expression::Number(meta.clone(), BigInt::from(1))),
                 };
-                let subs_access = Statement::Substitution{
+                let subs_access = Statement::Substitution {
                     meta: meta.clone(),
                     var: id_var_while,
                     access: Vec::new(),
                     op: AssignOp::AssignVar,
                     rhe: next_access,
                 };
-                    
-                let new_block = Statement::Block{
+                let new_block = Statement::Block {
                     meta: meta.clone(),
                     stmts: vec![body, subs_access],
                 };
                 Box::new(new_block)
-            } else{
+            } else {
                 Box::new(body)
             };
             Result::Ok((Statement::While { meta, cond, stmt: b_while}, comp_dec, var_declarations, subs_out))
-        },     
-
-        Statement::InitializationBlock { meta, xtype, initializations } =>
-        {
+        },
+        Statement::InitializationBlock { meta, xtype, initializations } => {
             let mut new_inits = Vec::new();
             let mut comp_inits = Vec::new();
             let mut var_inits = Vec::new();
             let mut subs = Vec::new();
 
             for stmt in initializations {
-                let (stmt_ok, mut comps, mut vars, mut sub) = remove_anonymous_from_statement(templates, file_lib, stmt, var_access)?;
+                let (stmt_ok, mut comps, mut vars, mut sub)
+                    = remove_anonymous_from_statement(templates, file_lib, stmt, var_access)?;
                 new_inits.push(stmt_ok);
                 comp_inits.append(&mut comps);
                 var_inits.append(&mut vars);
@@ -379,7 +363,8 @@ fn remove_anonymous_from_statement(
             let mut var_inits = Vec::new();
             let mut subs = Vec::new();
             for stmt in stmts {
-                let (stmt_ok, mut comps, mut vars, mut sub) = remove_anonymous_from_statement(templates, file_lib, stmt, var_access)?;
+                let (stmt_ok, mut comps, mut vars, mut sub)
+                    = remove_anonymous_from_statement(templates, file_lib, stmt, var_access)?;
                 new_stmts.push(stmt_ok);
                 comp_inits.append(&mut comps);
                 var_inits.append(&mut vars);
@@ -388,27 +373,27 @@ fn remove_anonymous_from_statement(
             Result::Ok((Statement::Block { meta, stmts: new_stmts}, comp_inits, var_inits, subs))
         }
         Statement::Substitution {  meta, var, op, rhe, access} => {
-            let (comp_declarations, mut stmts, new_rhe) = remove_anonymous_from_expression(templates, file_lib, rhe, var_access)?;
+            let (comp_declarations, mut stmts, new_rhe)
+                = remove_anonymous_from_expression(templates, file_lib, rhe, var_access)?;
             let subs = Statement::Substitution { meta: meta.clone(), var, access, op, rhe: new_rhe };
-            if stmts.is_empty(){
+            if stmts.is_empty() {
                 Result::Ok((subs, comp_declarations, Vec::new(), Vec::new()))
-            }else{
+            } else {
                 stmts.push(subs);
                 Result::Ok((Statement::Block { meta, stmts}, comp_declarations, Vec::new(), Vec::new()))   
             }
         }
         Statement::UnderscoreSubstitution { .. } => unreachable!(),
-        _ => {
-            Result::Ok((stm, Vec::new(), Vec::new(), Vec::new()))
-        }
+        _ => Result::Ok((stm, Vec::new(), Vec::new(), Vec::new())),
     }
 }
 
 // returns a block with the component declarations, the substitutions and finally the output expression
+#[allow(clippy::result_large_err)]
 pub fn remove_anonymous_from_expression(
-    templates : &HashMap<String, TemplateData>, 
-    file_lib : &FileLibrary,
-    exp : Expression,
+    templates: &HashMap<String, TemplateData>, 
+    file_lib: &FileLibrary,
+    exp: Expression,
     var_access: &Option<Expression>, // in case the call is inside a loop, variable used to control the access
 ) -> Result<UpdatedExpression,Report>{
     use Expression::*;
@@ -418,26 +403,27 @@ pub fn remove_anonymous_from_expression(
             let mut seq_substs = Vec::new();
 
             // get the template we are calling to
-            let template = templates.get(&id);
-            if template.is_none(){
-                return Result::Err(anonymous_general_error(meta.clone(),format!("The template {} does not exist", id)));
-            }
+            let template = match templates.get(&id) {
+                Some(t) => t,
+                None => return Result::Err(anonymous_general_error(meta.clone(),format!("The template {} does not exist", id))),
+            };
             let id_anon_temp = id.to_string() + "_" + &file_lib.get_line(meta.start, meta.get_file_id()).unwrap().to_string() + "_" + &meta.start.to_string();
             
             // in case we are not inside a loop, we can automatically convert into a component
-            if var_access.is_none(){
+            if let Some(va) = var_access {
+                // we generate an anonymous component, it depends on the var_access indicating the loop
                 declarations.push(build_declaration(
-                    meta.clone(), 
-                    VariableType::Component, 
+                    meta.clone(),
+                    VariableType::AnonymousComponent,
                     id_anon_temp.clone(),
-                    Vec::new(),
+                    vec![va.clone()],
                 ));
-            } else{ // we generate an anonymous component, it depends on the var_access indicating the loop
+            } else {
                 declarations.push(build_declaration(
-                    meta.clone(), 
-                    VariableType::AnonymousComponent, 
+                    meta.clone(),
+                    VariableType::Component,
                     id_anon_temp.clone(),
-                    vec![var_access.as_ref().unwrap().clone()],
+                    vec![],
                 ));
             }
 
@@ -449,17 +435,17 @@ pub fn remove_anonymous_from_expression(
                 call
             };
             // in case we are in a loop in only generates a position, needs the var_access reference
-            let access = if var_access.is_none(){
-                 Vec::new()
-            } else{
-                vec![build_array_access(var_access.as_ref().unwrap().clone())]
+            let access = if let Some(va) = var_access {
+                vec![build_array_access(va.clone())]
+            } else {
+                vec![]
             };
             // in loop: id_anon_temp[var_access] = (parallel) Template(params);
             // out loop: id_anon_temp = (parallel) Template(params)
             let sub = build_substitution(
                 meta.clone(), 
                 id_anon_temp.clone(), 
-                access.clone(), 
+                access, 
                 AssignOp::AssignVar, 
                 exp_with_call
             );
@@ -470,94 +456,76 @@ pub fn remove_anonymous_from_expression(
             let mut inputs_to_assignments = BTreeMap::new();
 
             if let Some(m) = names { // in case we have a list of names and assignments
-                let inputs = template.unwrap().get_inputs();
-                let mut n_expr = 0;
-                for (operator, name) in m{
-                    if operator != AssignOp::AssignConstraintSignal{
+                let inputs = template.get_inputs();
+                for (n_expr, (operator, name)) in m.into_iter().enumerate() {
+                    if operator != AssignOp::AssignConstraintSignal {
                         let error = "Anonymous components only admit the use of the operator <==".to_string();
-                        return Result::Err(anonymous_general_error(meta.clone(),error));
+                        return Result::Err(anonymous_general_error(meta.clone(), error));
                     }
-                    if inputs.contains_key(&name){
+                    if inputs.contains_key(&name) {
                         inputs_to_assignments.insert(name, (operator, signals[n_expr].clone()));
-                    } else{
-                        let error = format!("The template {} does not have an input signal named {}", template.unwrap().get_name(),  name);
-                        return Result::Err(anonymous_general_error(meta.clone(),error));
+                    } else {
+                        let error = format!("The template {} does not have an input signal named {}", template.get_name(), name);
+                        return Result::Err(anonymous_general_error(meta.clone(), error));
                     }
-                    n_expr += 1;
-                }   
+                }
                 if inputs.len() != inputs_to_assignments.len() {
-                    return Result::Err(anonymous_general_error(meta.clone(),"The number of template input signals must coincide with the number of input parameters ".to_string()));
-                }            
-            }
-            else{
-                let inputs = template.unwrap().get_declaration_inputs();
-                let mut n_expr = 0;
-                for value in signals {
+                    return Result::Err(anonymous_general_error(meta.clone(), "The number of template input signals must coincide with the number of input parameters ".to_string()));
+                }
+            } else {
+                let inputs = template.get_declaration_inputs();
+                for (n_expr, value) in signals.into_iter().enumerate() {
                     inputs_to_assignments.insert(inputs[n_expr].0.clone(), (AssignOp::AssignConstraintSignal, value));
-                    n_expr += 1;
                 }
-                
                 if inputs.len() != inputs_to_assignments.len() {
-                    return Result::Err(anonymous_general_error(meta.clone(),"The number of template input signals must coincide with the number of input parameters ".to_string()));
+                    return Result::Err(anonymous_general_error(meta.clone(), "The number of template input signals must coincide with the number of input parameters ".to_string()));
                 }
             }
-            
 
             // generate the substitutions for the inputs
-            for (name_signal, (operator, expr)) in inputs_to_assignments{
-                let mut acc = if var_access.is_none(){
-                    Vec::new()
-                } else{
-                    vec![build_array_access(var_access.as_ref().unwrap().clone())]
+            for (name, (op, exp)) in inputs_to_assignments {
+                let access = if let Some(va) = var_access {
+                    vec![build_array_access(va.clone()), Access::ComponentAccess(name)]
+                } else {
+                    vec![Access::ComponentAccess(name)]
                 };
-                acc.push(Access::ComponentAccess(name_signal.clone()));
-                let  (mut declarations2, mut stmts,new_exp) = remove_anonymous_from_expression(
-                        templates, 
-                        file_lib, 
-                        expr,
-                        var_access
-                )?;
- 
+                let (mut decs, mut stmts, rhe) =
+                    remove_anonymous_from_expression(templates, file_lib, exp, var_access)?;
                 seq_substs.append(&mut stmts);
-                declarations.append(&mut declarations2);
-                let subs = Statement::Substitution { meta: meta.clone(), var: id_anon_temp.clone(), access: acc, op: operator, rhe: new_exp };
+                declarations.append(&mut decs);
+                let subs = Statement::Substitution { meta: meta.clone(), var: id_anon_temp.clone(), access, op, rhe };
                 seq_substs.push(subs);
             }
+
             // generate the expression for the outputs -> return as expression (if single out) or tuple
-            let outputs = template.unwrap().get_declaration_outputs();
-            if outputs.len() == 1 {
-                let output = outputs.first().unwrap().0.clone();
-                let mut acc = if var_access.is_none(){
-                    Vec::new()
-                } else{
-                    vec![build_array_access(var_access.as_ref().unwrap().clone())]
-                };
-
-                acc.push(Access::ComponentAccess(output.clone()));
-                let out_exp = Expression::Variable { meta: meta.clone(), name: id_anon_temp, access: acc };
-                Result::Ok((declarations, vec![Statement::Block { meta: meta.clone(), stmts: seq_substs }], out_exp))
-
-             } else{
-                let mut new_values = Vec::new(); 
-                for output in outputs {
-                    let mut acc = if var_access.is_none(){
-                        Vec::new()
-                    } else{
-                        vec![build_array_access(var_access.as_ref().unwrap().clone())]
+            let out_exp = match &template.get_declaration_outputs()[..] {
+                [(name, _)] => {
+                    let access = if let Some(va) = var_access {
+                        vec![build_array_access(va.clone()), Access::ComponentAccess(name.clone())]
+                    } else {
+                        vec![Access::ComponentAccess(name.clone())]
                     };
-                    acc.push(Access::ComponentAccess(output.0.clone()));
-                    let out_exp = Expression::Variable { meta: meta.clone(), name: id_anon_temp.clone(), access: acc };
-                    new_values.push(out_exp);
+                    Expression::Variable { meta: meta.clone(), name: id_anon_temp, access }
                 }
-                let out_exp = Tuple {meta : meta.clone(), values : new_values};
-                Result::Ok((declarations, vec![Statement::Block { meta: meta.clone(), stmts: seq_substs }], out_exp))
-
-            }
+                outputs => {
+                    let mut values = Vec::new();
+                    for (name, _) in outputs {
+                        let access = if let Some(va) = var_access {
+                            vec![build_array_access(va.clone()), Access::ComponentAccess(name.clone())]
+                        } else {
+                            vec![Access::ComponentAccess(name.clone())]
+                        };
+                        values.push(Expression::Variable { meta: meta.clone(), name: id_anon_temp.clone(), access });
+                    }
+                    Tuple { meta: meta.clone(), values }
+                }
+            };
+            Result::Ok((declarations, vec![Statement::Block { meta: meta.clone(), stmts: seq_substs }], out_exp))
         },
         Tuple { meta, values } => {
             let mut new_values = Vec::new();
-            let mut new_stmts : Vec<Statement> = Vec::new();
-            let mut declarations : Vec<Statement> = Vec::new();
+            let mut new_stmts: Vec<Statement> = Vec::new();
+            let mut declarations: Vec<Statement> = Vec::new();
             for val in values{
                 let result = remove_anonymous_from_expression(templates, file_lib, val, var_access);
                 match result {
@@ -572,44 +540,41 @@ pub fn remove_anonymous_from_expression(
             Result::Ok((declarations, new_stmts, build_tuple(meta.clone(), new_values)))
         },
         ParallelOp { meta, rhe } => {
-            if rhe.is_anonymous_comp(){
+            if rhe.is_anonymous_comp() {
                 let rhe2 = rhe.make_anonymous_parallel();
                 remove_anonymous_from_expression(templates, file_lib, rhe2, var_access)
-            } else{
+            } else {
                 Result::Ok((Vec::new(),Vec::new(), ParallelOp { meta, rhe }))
             }
         },
-        _ =>{
-            Result::Ok((Vec::new(),Vec::new(),exp))
+        _ => {
+            Result::Ok((Vec::new(),Vec::new(), exp))
         }
     }
 }
 
-
-fn check_tuples_statement(stm: &Statement)-> Result<(), Report>{
-    match stm{
+fn check_tuples_statement(stm: &Statement)-> Result<(), Box<Report>> {
+    match stm {
         Statement::MultSubstitution { lhe, rhe, ..  } => {
             check_tuples_expression(lhe)?;
             check_tuples_expression(rhe)?;
             Result::Ok(())
         },
-        Statement::IfThenElse { cond, if_case, else_case, meta, .. } 
-        => { 
+        Statement::IfThenElse { cond, if_case, else_case, meta, .. } => { 
             if cond.contains_tuple() {
-                Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used inside a condition ".to_string()))     
-            } else{
+                Result::Err(Box::new(tuple_general_error(meta.clone(), "A tuple cannot be used inside a condition ".to_string())))
+            } else {
                 check_tuples_statement(if_case)?;
-                if else_case.is_some(){
-                    check_tuples_statement(else_case.as_ref().unwrap())?;
+                if let Some(stm) = else_case {
+                    check_tuples_statement(stm)?;
                 }
                 Result::Ok(())
             }
         }
-
-        Statement::While { meta, cond, stmt }   => {
+        Statement::While { meta, cond, stmt } => {
             if cond.contains_tuple() {
-                Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used inside a condition ".to_string()))       
-           } else{      
+                Result::Err(Box::new(tuple_general_error(meta.clone(), "A tuple cannot be used inside a condition ".to_string())))
+            } else {      
                 check_tuples_statement(stmt)
             }
         }     
@@ -624,42 +589,36 @@ fn check_tuples_statement(stm: &Statement)-> Result<(), Report>{
             }
             Result::Ok(())
         }  
-        Statement::Assert { meta, arg}   => { 
-            if arg.contains_tuple(){
-                Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used in a return ".to_string()))       
-            }
-            else{ 
+        Statement::Assert { meta, arg} => { 
+            if arg.contains_tuple() {
+                Result::Err(Box::new(tuple_general_error(meta.clone(), "A tuple cannot be used in a return ".to_string())))
+            } else { 
                 Result::Ok(())
             }
         }
         Statement::Return {  meta, value: arg}=> {
-            if arg.contains_tuple(){
-                Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used inside a function ".to_string()))     
-            }
-            else{ 
+            if arg.contains_tuple() {
+                Result::Err(Box::new(tuple_general_error(meta.clone(), "A tuple cannot be used inside a function ".to_string())))
+            } else { 
                 Result::Ok(())
             }
         }
         Statement::ConstraintEquality {meta, lhe, rhe } => {
             if lhe.contains_tuple() || rhe.contains_tuple() {
-                Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used with the operator === ".to_string()))       
-            }
-            else{ 
+                Result::Err(Box::new(tuple_general_error(meta.clone(), "A tuple cannot be used with the operator === ".to_string())))
+            } else { 
                 Result::Ok(()) 
             }
         }
-        Statement::Declaration { meta,
-                                 dimensions, .. } =>
-        {
-            for exp in dimensions.clone(){
-                if exp.contains_tuple(){
-                    return Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used to define a dimension of an array ".to_string()));       
+        Statement::Declaration { meta, dimensions, .. } => {
+            for exp in dimensions {
+                if exp.contains_tuple() {
+                    return Result::Err(Box::new(tuple_general_error(meta.clone(), "A tuple cannot be used to define a dimension of an array ".to_string())));  
                 }
             }
             Result::Ok(())
         }
-        Statement::InitializationBlock {initializations, ..} =>
-        {
+        Statement::InitializationBlock {initializations, ..} => {
             for stmt in initializations {
                 check_tuples_statement(stmt)?;
             }
@@ -675,36 +634,36 @@ fn check_tuples_statement(stm: &Statement)-> Result<(), Report>{
             use program_structure::ast::Access::ComponentAccess;
             use program_structure::ast::Access::ArrayAccess;
             for acc in access{
-                match acc{
-                    ArrayAccess(exp) =>{
-                        if exp.contains_tuple(){
-                            return Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used to define a dimension of an array".to_string()));
+                match acc {
+                    ArrayAccess(exp) => {
+                        if exp.contains_tuple() {
+                            return Result::Err(Box::new(tuple_general_error(meta.clone(), "A tuple cannot be used to define a dimension of an array".to_string())));
                         }
                     },
-                    ComponentAccess(_)=>{},
+                    ComponentAccess(_) => {},
                 }
             }
-            check_tuples_expression(rhe)
+            check_tuples_expression(rhe).map_err(Box::new)
         }
         Statement::UnderscoreSubstitution { .. } => unreachable!(),
     }
 }
 
-
-pub fn check_tuples_expression(exp: &Expression) -> Result<(), Report>{
+#[allow(clippy::result_large_err)]
+pub fn check_tuples_expression(exp: &Expression) -> Result<(), Report> {
     use Expression::*;
     match exp{
         ArrayInLine { meta, values } => {    
             for value in values{
                 if value.contains_tuple() {
-                    return Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used to define a dimension of an array ".to_string()));       
+                    return Result::Err(tuple_general_error(meta.clone(), "A tuple cannot be used to define a dimension of an array ".to_string()));       
                 }
             }
             Result::Ok(())
         }, 
         UniformArray { meta, value, dimension } => {
             if value.contains_tuple() || dimension.contains_tuple() {
-                return Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used to define a dimension of an array ".to_string()));       
+                return Result::Err(tuple_general_error(meta.clone(), "A tuple cannot be used to define a dimension of an array ".to_string()));       
             }
             Result::Ok(())
         },
@@ -714,42 +673,42 @@ pub fn check_tuples_expression(exp: &Expression) -> Result<(), Report>{
         Variable { access, meta,  .. } => {
             use program_structure::ast::Access::*;
             for acc in access{
-                match acc{
-                    ArrayAccess(exp) =>{
-                        if exp.contains_tuple(){
-                            return Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used to define a dimension of an array".to_string()));
+                match acc {
+                    ArrayAccess(exp) => {
+                        if exp.contains_tuple() {
+                            return Result::Err(tuple_general_error(meta.clone(), "A tuple cannot be used to define a dimension of an array".to_string()));
                         }
                     },
-                    ComponentAccess(_)=>{},
+                    ComponentAccess(_) => {},
                 }
             }
             Result::Ok(())
         },
         InfixOp { meta, lhe, rhe, .. } => {
             if lhe.contains_tuple() || rhe.contains_tuple() {
-                Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used in the middle of an operation".to_string()))     
-            } else{
+                Result::Err(tuple_general_error(meta.clone(), "A tuple cannot be used in the middle of an operation".to_string()))     
+            } else {
                 Result::Ok(())
             }
         },
         PrefixOp { meta, rhe, .. } => {
             if rhe.contains_tuple()  {
-                Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used in the middle of an operation".to_string()))     
-            } else{
+                Result::Err(tuple_general_error(meta.clone(), "A tuple cannot be used in the middle of an operation".to_string()))     
+            } else {
                 Result::Ok(())
             }
         },
         InlineSwitchOp { meta, cond, if_true,  if_false } => {
             if cond.contains_tuple() || if_true.contains_tuple() || if_false.contains_tuple() {
-                Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used inside an inline switch".to_string()))      
-            } else{
+                Result::Err(tuple_general_error(meta.clone(), "A tuple cannot be used inside an inline switch".to_string()))      
+            } else {
                 Result::Ok(())
             }
         },
         Call { meta, args, .. } => {
-            for value in args{
+            for value in args {
                 if value.contains_tuple() {
-                    return Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used as a parameter of a function call".to_string()));       
+                    return Result::Err(tuple_general_error(meta.clone(), "A tuple cannot be used as a parameter of a function call".to_string()));       
                 }
             }
             Result::Ok(())
@@ -765,16 +724,16 @@ pub fn check_tuples_expression(exp: &Expression) -> Result<(), Report>{
         },
         ParallelOp { meta, rhe} => {
             if rhe.contains_tuple()  {
-                Result::Err(tuple_general_error(meta.clone(),"A tuple cannot be used in a parallel operator ".to_string()))       
-            } else{
+                Result::Err(tuple_general_error(meta.clone(), "A tuple cannot be used in a parallel operator ".to_string()))       
+            } else {
                 Result::Ok(())
             }
         },
     }
 }
 
-fn remove_tuples_from_statement(stm: Statement) -> Result<Statement, Report> {
-    match stm{
+fn remove_tuples_from_statement(stm: Statement) -> Result<Statement, Box<Report>> {
+    match stm {
         Statement::MultSubstitution { meta, lhe, op, rhe  } => {
             let new_exp_lhe = remove_tuple_from_expression(lhe);
             let new_exp_rhe = remove_tuple_from_expression(rhe);
@@ -783,53 +742,49 @@ fn remove_tuples_from_statement(stm: Statement) -> Result<Statement, Report> {
                     Expression::Tuple { values: mut values2, .. }) => {
                     if values1.len() == values2.len() {
                         let mut substs = Vec::new();
-                        while  !values1.is_empty() {
+                        while !values1.is_empty() {
                             let lhe = values1.remove(0);
                             if let Expression::Variable { meta, name, access } = lhe {  
                                 let rhe = values2.remove(0);
                                 if name != "_" {                                
                                     substs.push(build_substitution(meta, name, access, op, rhe));
-                                } else{
+                                } else {
                                     substs.push(Statement::UnderscoreSubstitution { meta, op, rhe });
                                 }
-                            } else{   
-                                return Result::Err(tuple_general_error(meta.clone(),"The elements of the receiving tuple must be signals or variables.".to_string()));
+                            } else {   
+                                return Result::Err(Box::new(tuple_general_error(meta.clone(), "The elements of the receiving tuple must be signals or variables.".to_string())));
                             }
                         }
                         Result::Ok(build_block(meta.clone(),substs))
                     } else if !values1.is_empty() {
-                        return Result::Err(tuple_general_error(meta.clone(),"The number of elements in both tuples does not coincide".to_string()));           
+                        return Result::Err(Box::new(tuple_general_error(meta.clone(), "The number of elements in both tuples does not coincide".to_string())));
                     } else {
-                        return Result::Err(tuple_general_error(meta.clone(),"This expression must be in the right side of an assignment".to_string()));           
+                        return Result::Err(Box::new(tuple_general_error(meta.clone(), "This expression must be in the right side of an assignment".to_string())));
                     }
                 },
                 (lhe, rhe) => { 
-                    if lhe.is_tuple() || lhe.is_variable(){
-                        return Result::Err(tuple_general_error(rhe.get_meta().clone(),"This expression must be a tuple or an anonymous component".to_string()));
+                    if lhe.is_tuple() || lhe.is_variable() {
+                        return Result::Err(Box::new(tuple_general_error(rhe.get_meta().clone(), "This expression must be a tuple or an anonymous component".to_string())));
                     } else {
-                        return Result::Err(tuple_general_error(lhe.get_meta().clone(),"This expression must be a tuple, a component, a signal or a variable ".to_string()));    
+                        return Result::Err(Box::new(tuple_general_error(lhe.get_meta().clone(), "This expression must be a tuple, a component, a signal or a variable ".to_string())));
                     }
                 }
             }
         },
-        Statement::IfThenElse { meta, cond, if_case, else_case } 
-        => { 
+        Statement::IfThenElse { meta, cond, if_case, else_case } => { 
             let if_ok = remove_tuples_from_statement(*if_case)?;
-            let b_if = Box::new(if_ok);
-            if else_case.is_none(){
-                Result::Ok(Statement::IfThenElse { meta, cond, if_case: b_if, else_case: Option::None})
-            }else {
-                let else_c = *(else_case.unwrap());
-                let else_ok = remove_tuples_from_statement(else_c)?;
-                let b_else = Box::new(else_ok);
-                Result::Ok(Statement::IfThenElse { meta, cond, if_case: b_if, else_case: Option::Some(b_else)})
-            }
+            let b_else = if let Some(stm) = else_case {
+                let else_ok = remove_tuples_from_statement(*stm)?;
+                Option::Some(Box::new(else_ok))
+            } else {
+                Option::None
+            };
+            Result::Ok(Statement::IfThenElse { meta, cond, if_case: Box::new(if_ok), else_case: b_else})
         }
-
-        Statement::While { meta, cond, stmt }   => {
+        Statement::While { meta, cond, stmt } => {
             let while_ok = remove_tuples_from_statement(*stmt)?;
             let b_while = Box::new(while_ok);
-            Result::Ok(Statement::While { meta, cond, stmt : b_while})
+            Result::Ok(Statement::While { meta, cond, stmt: b_while})
         }     
         Statement::LogCall {meta, args } => {
             let mut newargs = Vec::new();
@@ -846,8 +801,7 @@ fn remove_tuples_from_statement(stm: Statement) -> Result<Statement, Report> {
             }
             Result::Ok(build_log_call(meta, newargs))
         }  
-        Statement::InitializationBlock { meta, xtype, initializations } =>
-        {
+        Statement::InitializationBlock { meta, xtype, initializations } => {
             let mut new_inits = Vec::new();
             for stmt in initializations {
                 let stmt_ok = remove_tuples_from_statement(stmt)?;
@@ -866,12 +820,11 @@ fn remove_tuples_from_statement(stm: Statement) -> Result<Statement, Report> {
         Statement::Substitution {  meta, var, op, rhe, access} => {
             let new_rhe = remove_tuple_from_expression(rhe);
             if new_rhe.is_tuple() {
-                return Result::Err(tuple_general_error(meta.clone(),"Left-side of the statement is not a tuple".to_string()));       
+                return Result::Err(Box::new(tuple_general_error(meta.clone(), "Left-side of the statement is not a tuple".to_string())));
             }
             if var != "_" {   
                 Result::Ok(Statement::Substitution { meta: meta.clone(), var, access, op, rhe: new_rhe })
-            }
-            else {
+            } else {
                 Result::Ok(Statement::UnderscoreSubstitution { meta, op, rhe: new_rhe })
             }
         }
@@ -883,7 +836,7 @@ fn remove_tuples_from_statement(stm: Statement) -> Result<Statement, Report> {
 fn separate_tuple_for_logcall(values: Vec<Expression>) ->  Vec<LogArgument> {
     let mut new_values = Vec::new();
     for val in values {
-        if let Expression::Tuple {  values : values2, .. } = val {
+        if let Expression::Tuple {  values: values2, .. } = val {
             new_values.push(LogArgument::LogStr("(".to_string()));
             let mut new_values2 = separate_tuple_for_logcall(values2);
             new_values.append(&mut new_values2);
@@ -896,8 +849,7 @@ fn separate_tuple_for_logcall(values: Vec<Expression>) ->  Vec<LogArgument> {
     new_values
 }
 
-
-pub fn remove_tuple_from_expression(exp : Expression) -> Expression{
+pub fn remove_tuple_from_expression(exp: Expression) -> Expression{
     use Expression::*;
     match exp {
         AnonymousComp { .. } => {

--- a/program_structure/src/abstract_syntax_tree/assign_op_impl.rs
+++ b/program_structure/src/abstract_syntax_tree/assign_op_impl.rs
@@ -3,9 +3,6 @@ use super::ast::AssignOp;
 impl AssignOp {
     pub fn is_signal_operator(self) -> bool {
         use AssignOp::*;
-        match self {
-            AssignConstraintSignal | AssignSignal => true,
-            _ => false,
-        }
+        matches!(self, AssignConstraintSignal | AssignSignal)
     }
 }

--- a/program_structure/src/abstract_syntax_tree/ast.rs
+++ b/program_structure/src/abstract_syntax_tree/ast.rs
@@ -483,7 +483,7 @@ impl MemoryKnowledge {
                 )
             }
             MissingSemicolon => {
-                let mut report = Report::error(format!("Missing semicolon"), 
+                let mut report = Report::error("Missing semicolon".to_string(), 
                     ReportCode::MissingSemicolon);
                 report.add_primary(location, file_id, "A semicolon is needed here".to_string());
                 report
@@ -565,20 +565,20 @@ pub fn produce_report_with_message(error_code : ReportCode, msg : String) -> Rep
 }
 
 pub fn produce_compiler_version_report(path : String, required_version : Version, version :  Version) -> Report {
-    let report = Report::error(
+    
+    Report::error(
         format!("File {} requires pragma version {:?} that is not supported by the compiler (version {:?})", path, required_version, version ),
         ReportCode::CompilerVersionError,
-    );
-    report
+    )
 }
 
 pub fn anonymous_inside_condition_error(meta : Meta) -> Report {
     let msg = "An anonymous component cannot be used inside a condition ".to_string();
                 let mut report = Report::error(
-                    format!("{}", msg),
+                    msg.to_string(),
                     ReportCode::AnonymousCompError,
                 );
-                let file_id = meta.get_file_id().clone();
+                let file_id = meta.get_file_id();
                 report.add_primary(
                     meta.location,
                     file_id,
@@ -589,10 +589,10 @@ pub fn anonymous_inside_condition_error(meta : Meta) -> Report {
 
 pub fn anonymous_general_error(meta : Meta, msg : String) -> Report {
     let mut report = Report::error(
-                    format!("{}", msg),
+                    msg.to_string(),
                     ReportCode::AnonymousCompError,
                 );
-                let file_id = meta.get_file_id().clone();
+                let file_id = meta.get_file_id();
                 report.add_primary(
                     meta.location,
                     file_id,
@@ -603,10 +603,10 @@ pub fn anonymous_general_error(meta : Meta, msg : String) -> Report {
 
 pub fn tuple_general_error(meta : Meta, msg : String) -> Report {
     let mut report = Report::error(
-                    format!("{}", msg),
+                    msg.to_string(),
                     ReportCode::TupleError,
                 );
-                let file_id = meta.get_file_id().clone();
+                let file_id = meta.get_file_id();
                 report.add_primary(
                     meta.location,
                     file_id,

--- a/program_structure/src/abstract_syntax_tree/ast.rs
+++ b/program_structure/src/abstract_syntax_tree/ast.rs
@@ -1,4 +1,4 @@
-use crate::{file_definition::{FileLocation, FileID}, error_definition::Report, error_code::{ReportCode}};
+use crate::{file_definition::{FileLocation, FileID}, error_definition::Report, error_code::ReportCode};
 use num_bigint::BigInt;
 use serde_derive::{Deserialize, Serialize};
 

--- a/program_structure/src/abstract_syntax_tree/ast_shortcuts.rs
+++ b/program_structure/src/abstract_syntax_tree/ast_shortcuts.rs
@@ -114,7 +114,7 @@ pub fn split_declaration_into_single_nodes_and_multisubstitution(
                 build_substitution(meta.clone(), symbol.name, vec![], AssignOp::AssignVar, value);
             initializations.push(substitution);
         }
-        values.push(Expression::Variable { meta: with_meta.clone(), name: name, access: Vec::new() })
+        values.push(Expression::Variable { meta: with_meta.clone(), name, access: Vec::new() })
     }
     if let Some( tuple) = init {
         let (op,expression) = tuple.tuple_init;

--- a/program_structure/src/abstract_syntax_tree/expression_impl.rs
+++ b/program_structure/src/abstract_syntax_tree/expression_impl.rs
@@ -38,93 +38,51 @@ impl Expression {
 
     pub fn is_array(&self) -> bool {
         use Expression::*;
-        if let ArrayInLine { .. } = self {
-            true
-        } else if let UniformArray { .. } = self{
-            true
-        } else {
-            false
-        }
+        matches!(self, ArrayInLine { .. } | UniformArray { .. })
     }
 
     pub fn is_infix(&self) -> bool {
         use Expression::*;
-        if let InfixOp { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, InfixOp { .. })
     }
 
     pub fn is_prefix(&self) -> bool {
         use Expression::*;
-        if let PrefixOp { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, PrefixOp { .. })
     }
-    
+
     pub fn is_tuple(&self) -> bool {
         use Expression::*;
-        if let Tuple { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Tuple { .. })
     }
     pub fn is_switch(&self) -> bool {
         use Expression::*;
-        if let InlineSwitchOp { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, InlineSwitchOp { .. })
     }
 
     pub fn is_parallel(&self) -> bool {
         use Expression::*;
-        if let ParallelOp { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, ParallelOp { .. })
     }
 
     pub fn is_variable(&self) -> bool {
         use Expression::*;
-        if let Variable { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Variable { .. })
     }
 
     pub fn is_number(&self) -> bool {
         use Expression::*;
-        if let Number(..) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Number(..))
     }
 
     pub fn is_call(&self) -> bool {
         use Expression::*;
-        if let Call { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Call { .. })
     }
 
     pub fn is_anonymous_comp(&self) -> bool {
         use Expression::*;
-        if let AnonymousComp { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnonymousComp { .. })
     }
 
     pub fn make_anonymous_parallel(self) -> Expression {

--- a/program_structure/src/abstract_syntax_tree/statement_builders.rs
+++ b/program_structure/src/abstract_syntax_tree/statement_builders.rs
@@ -7,7 +7,7 @@ pub fn build_conditional_block(
     if_case: Statement,
     else_case: Option<Statement>,
 ) -> Statement {
-    IfThenElse { meta, cond, else_case: else_case.map(|s| Box::new(s)), if_case: Box::new(if_case) }
+    IfThenElse { meta, cond, else_case: else_case.map(Box::new), if_case: Box::new(if_case) }
 }
 
 pub fn build_while_block(meta: Meta, cond: Expression, stmt: Statement) -> Statement {

--- a/program_structure/src/abstract_syntax_tree/statement_impl.rs
+++ b/program_structure/src/abstract_syntax_tree/statement_impl.rs
@@ -38,92 +38,48 @@ impl Statement {
 
     pub fn is_if_then_else(&self) -> bool {
         use Statement::IfThenElse;
-        if let IfThenElse { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, IfThenElse { .. })
     }
     pub fn is_while(&self) -> bool {
         use Statement::While;
-        if let While { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, While { .. })
     }
     pub fn is_return(&self) -> bool {
         use Statement::Return;
-        if let Return { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Return { .. })
     }
     pub fn is_initialization_block(&self) -> bool {
         use Statement::InitializationBlock;
-        if let InitializationBlock { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, InitializationBlock { .. })
     }
     pub fn is_declaration(&self) -> bool {
         use Statement::Declaration;
-        if let Declaration { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Declaration { .. })
     }
     pub fn is_substitution(&self) -> bool {
         use Statement::Substitution;
-        if let Substitution { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Substitution { .. })
     }
 
     pub fn is_underscore_substitution(&self) -> bool {
         use Statement::UnderscoreSubstitution;
-        if let UnderscoreSubstitution { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, UnderscoreSubstitution { .. })
     }
     pub fn is_constraint_equality(&self) -> bool {
         use Statement::ConstraintEquality;
-        if let ConstraintEquality { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, ConstraintEquality { .. })
     }
     pub fn is_log_call(&self) -> bool {
         use Statement::LogCall;
-        if let LogCall { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, LogCall { .. })
     }
     pub fn is_block(&self) -> bool {
         use Statement::Block;
-        if let Block { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Block { .. })
     }
     pub fn is_assert(&self) -> bool {
         use Statement::Assert;
-        if let Assert { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Assert { .. })
     }
 
     pub fn contains_anonymous_comp(&self) -> bool {

--- a/program_structure/src/program_library/error_definition.rs
+++ b/program_structure/src/program_library/error_definition.rs
@@ -60,7 +60,7 @@ impl Report {
             diagnostics.push(report.to_diagnostic());
         }
         for diagnostic in diagnostics.iter() {
-            let print_result = term::emit(&mut writer.lock(), &config, files, &diagnostic);
+            let print_result = term::emit(&mut writer.lock(), &config, files, diagnostic);
             if print_result.is_err() {
                 panic!("Error printing reports")
             }

--- a/program_structure/src/program_library/error_definition.rs
+++ b/program_structure/src/program_library/error_definition.rs
@@ -16,17 +16,11 @@ pub enum MessageCategory {
 impl MessageCategory {
     fn is_error(&self) -> bool {
         use MessageCategory::*;
-        match self {
-            Error => true,
-            _ => false,
-        }
+        matches!(self, Error)
     }
     fn is_warning(&self) -> bool {
         use MessageCategory::*;
-        match self {
-            Warning => true,
-            _ => false,
-        }
+        matches!(self, Warning)
     }
 }
 

--- a/program_structure/src/program_library/file_definition.rs
+++ b/program_structure/src/program_library/file_definition.rs
@@ -26,13 +26,10 @@ impl FileLibrary {
         self.get_mut_files().add(file_name, file_source)
     }
     pub fn get_line(&self, start: usize, file_id: FileID) -> Option<usize> {
-        match self.files.line_index(file_id, start) {
-            Some(lines) => Some(lines + 1),
-            None => None,
-        }
+        self.files.line_index(file_id, start).map(|lines| lines + 1)
     }
     pub fn to_storage(&self) -> &FileStorage {
-        &self.get_files()
+        self.get_files()
     }
     fn get_files(&self) -> &FileStorage {
         &self.files

--- a/program_structure/src/program_library/program_merger.rs
+++ b/program_structure/src/program_library/program_merger.rs
@@ -5,20 +5,13 @@ use super::file_definition::FileID;
 use super::function_data::{FunctionData, FunctionInfo};
 use super::template_data::{TemplateData, TemplateInfo};
 
+#[derive(Default)]
 pub struct Merger {
     fresh_id: usize,
     function_info: FunctionInfo,
     template_info: TemplateInfo,
 }
-impl Default for Merger {
-    fn default() -> Self {
-        Merger {
-            fresh_id: 0,
-            function_info: FunctionInfo::new(),
-            template_info: TemplateInfo::new(),
-        }
-    }
-}
+
 
 impl Merger {
     pub fn new() -> Merger {

--- a/program_structure/src/program_library/template_data.rs
+++ b/program_structure/src/program_library/template_data.rs
@@ -27,6 +27,7 @@ pub struct TemplateData {
 }
 
 impl TemplateData {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: String,
         file_id: FileID,
@@ -60,6 +61,7 @@ impl TemplateData {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn copy(
         name: String,
         file_id: FileID,
@@ -179,26 +181,23 @@ fn fill_inputs_and_outputs(
                 fill_inputs_and_outputs(initialization, input_signals, output_signals, input_declarations, output_declarations);
             }
         }
-        Statement::Declaration { xtype, name, dimensions, .. } => {
-            if let ast::VariableType::Signal(stype, tag_list) = xtype {
-                let signal_name = name.clone();
-                let dim = dimensions.len();
-                let mut tag_info = HashSet::new();
-                for tag in tag_list{
-                    tag_info.insert(tag.clone());
+        Statement::Declaration { xtype: ast::VariableType::Signal(stype, tag_list), name, dimensions, .. } => {
+            let signal_name = name.clone();
+            let dim = dimensions.len();
+            let mut tag_info = HashSet::new();
+            for tag in tag_list {
+                tag_info.insert(tag.clone());
+            }
+            match stype {
+                ast::SignalType::Input => {
+                    input_signals.insert(signal_name.clone(), (dim, tag_info));
+                    input_declarations.push((signal_name, dim));
                 }
-
-                match stype {
-                    ast::SignalType::Input => {
-                        input_signals.insert(signal_name.clone(), (dim, tag_info));
-                        input_declarations.push((signal_name,dim));
-                    }
-                    ast::SignalType::Output => {
-                        output_signals.insert(signal_name.clone(), (dim, tag_info));
-                        output_declarations.push((signal_name,dim));
-                    }
-                    _ => {} //no need to deal with intermediate signals
+                ast::SignalType::Output => {
+                    output_signals.insert(signal_name.clone(), (dim, tag_info));
+                    output_declarations.push((signal_name, dim));
                 }
+                _ => {} //no need to deal with intermediate signals
             }
         }
         _ => {}

--- a/program_structure/src/program_library/template_data.rs
+++ b/program_structure/src/program_library/template_data.rs
@@ -136,7 +136,7 @@ impl TemplateData {
         &self.output_signals
     }
     pub fn get_declaration_inputs(&self) -> &SignalDeclarationOrder {
-        &&self.input_declarations
+        &self.input_declarations
     }
     pub fn get_declaration_outputs(&self) -> &SignalDeclarationOrder {
         &self.output_declarations

--- a/program_structure/src/utils/environment.rs
+++ b/program_structure/src/utils/environment.rs
@@ -218,7 +218,7 @@ where
         self.components.get_mut(symbol)
     }
     pub fn get_component_res(&self, symbol: &str) -> Result<&CC, CircomEnvironmentError> {
-        self.components.get(symbol).ok_or_else(|| CircomEnvironmentError::NonExistentSymbol)
+        self.components.get(symbol).ok_or(CircomEnvironmentError::NonExistentSymbol)
     }
     pub fn get_component_or_break(&self, symbol: &str, file: &str, line: u32) -> &CC {
         assert!(self.has_component(symbol), "Method call in file {} line {}", file, line);
@@ -228,7 +228,7 @@ where
         &mut self,
         symbol: &str,
     ) -> Result<&mut CC, CircomEnvironmentError> {
-        self.components.get_mut(symbol).ok_or_else(|| CircomEnvironmentError::NonExistentSymbol)
+        self.components.get_mut(symbol).ok_or(CircomEnvironmentError::NonExistentSymbol)
     }
     pub fn get_mut_component_or_break(&mut self, symbol: &str, file: &str, line: u32) -> &mut CC {
         assert!(self.has_component(symbol), "Method call in file {} line {}", file, line);
@@ -280,14 +280,14 @@ where
         self.inputs.get_mut(symbol)
     }
     pub fn get_input_res(&self, symbol: &str) -> Result<&SC, CircomEnvironmentError> {
-        self.inputs.get(symbol).ok_or_else(|| CircomEnvironmentError::NonExistentSymbol)
+        self.inputs.get(symbol).ok_or(CircomEnvironmentError::NonExistentSymbol)
     }
     pub fn get_input_or_break(&self, symbol: &str, file: &str, line: u32) -> &SC {
         assert!(self.has_input(symbol), "Method call in file {} line {}", file, line);
         self.inputs.get(symbol).unwrap()
     }
     pub fn get_mut_input_res(&mut self, symbol: &str) -> Result<&mut SC, CircomEnvironmentError> {
-        self.inputs.get_mut(symbol).ok_or_else(|| CircomEnvironmentError::NonExistentSymbol)
+        self.inputs.get_mut(symbol).ok_or(CircomEnvironmentError::NonExistentSymbol)
     }
     pub fn get_mut_input_or_break(&mut self, symbol: &str, file: &str, line: u32) -> &mut SC {
         assert!(self.has_input(symbol), "Method call in file {} line {}", file, line);
@@ -301,14 +301,14 @@ where
         self.outputs.get_mut(symbol)
     }
     pub fn get_output_res(&self, symbol: &str) -> Result<&SC, CircomEnvironmentError> {
-        self.outputs.get(symbol).ok_or_else(|| CircomEnvironmentError::NonExistentSymbol)
+        self.outputs.get(symbol).ok_or(CircomEnvironmentError::NonExistentSymbol)
     }
     pub fn get_output_or_break(&self, symbol: &str, file: &str, line: u32) -> &SC {
         assert!(self.has_output(symbol), "Method call in file {} line {}", file, line);
         self.outputs.get(symbol).unwrap()
     }
     pub fn get_mut_output_res(&mut self, symbol: &str) -> Result<&mut SC, CircomEnvironmentError> {
-        self.outputs.get_mut(symbol).ok_or_else(|| CircomEnvironmentError::NonExistentSymbol)
+        self.outputs.get_mut(symbol).ok_or(CircomEnvironmentError::NonExistentSymbol)
     }
     pub fn get_mut_output_or_break(&mut self, symbol: &str, file: &str, line: u32) -> &mut SC {
         assert!(self.has_output(symbol), "Method call in file {} line {}", file, line);
@@ -322,7 +322,7 @@ where
         self.intermediates.get_mut(symbol)
     }
     pub fn get_intermediate_res(&self, symbol: &str) -> Result<&SC, CircomEnvironmentError> {
-        self.intermediates.get(symbol).ok_or_else(|| CircomEnvironmentError::NonExistentSymbol)
+        self.intermediates.get(symbol).ok_or(CircomEnvironmentError::NonExistentSymbol)
     }
     pub fn get_intermediate_or_break(&self, symbol: &str, file: &str, line: u32) -> &SC {
         assert!(self.has_intermediate(symbol), "Method call in file {} line {}", file, line);
@@ -332,7 +332,7 @@ where
         &mut self,
         symbol: &str,
     ) -> Result<&mut SC, CircomEnvironmentError> {
-        self.intermediates.get_mut(symbol).ok_or_else(|| CircomEnvironmentError::NonExistentSymbol)
+        self.intermediates.get_mut(symbol).ok_or(CircomEnvironmentError::NonExistentSymbol)
     }
     pub fn get_mut_intermediate_or_break(
         &mut self,

--- a/program_structure/src/utils/memory_slice.rs
+++ b/program_structure/src/utils/memory_slice.rs
@@ -373,7 +373,7 @@ mod tests {
                 if let Result::Ok(v) = result {
                     assert_eq!(*v, 0);
                 } else {
-                    assert!(false);
+                    unreachable!();
                 }
             }
         }
@@ -386,7 +386,7 @@ mod tests {
         if let Result::Ok(val) = memory_response {
             assert_eq!(*val, 4);
         } else {
-            assert!(false);
+            unreachable!();
         }
     }
     #[test]
@@ -402,11 +402,11 @@ mod tests {
                 if let Result::Ok(val) = memory_result {
                     assert_eq!(*val, 4);
                 } else {
-                    assert!(false);
+                    unreachable!();
                 }
             }
         } else {
-            assert!(false);
+            unreachable!();
         }
     }
 }

--- a/program_structure/src/utils/memory_slice.rs
+++ b/program_structure/src/utils/memory_slice.rs
@@ -64,7 +64,7 @@ impl<C: Default + Clone + Display + Eq> Display for MemorySlice<C> {
             for i in 1..self.values.len() {
                 msg.push_str(&format!(",{}", self.values[i]));
             }
-            msg.push_str("]");
+            msg.push(']');
             f.write_str(&msg)
         }
     }
@@ -239,7 +239,7 @@ impl<C: Clone> MemorySlice<C> {
                 }
                 Result::Err(MemoryError::MismatchedDimensionsWeak(dim_1, dim_2))
             }
-            Result::Err(error) => return Err(error),
+            Result::Err(error) => Err(error),
         }
     }
 
@@ -253,7 +253,7 @@ impl<C: Clone> MemorySlice<C> {
         }
         memory_slice.number_inserts += 1;
         memory_slice.values[index] = new_value;
-        return Result::Ok(());
+        Result::Ok(())
     }
 
     pub fn get_access_index(
@@ -262,16 +262,16 @@ impl<C: Clone> MemorySlice<C> {
     ) -> Result<Vec<SliceCapacity>, MemoryError> {
         let mut number_cells = MemorySlice::get_number_of_cells(memory_slice);
         if index > number_cells {
-            return Result::Err(MemoryError::OutOfBoundsError);
+            Result::Err(MemoryError::OutOfBoundsError)
         } else {
             let mut access = vec![];
             let mut index_aux = index;
             for pos in &memory_slice.route {
-                number_cells = number_cells / pos;
+                number_cells /= pos;
                 access.push(index_aux / number_cells);
-                index_aux = index_aux % number_cells;
+                index_aux %= number_cells;
             }
-            return Result::Ok(access);
+            Result::Ok(access)
         }
     }
 
@@ -288,7 +288,7 @@ impl<C: Clone> MemorySlice<C> {
         if index > MemorySlice::get_number_of_cells(memory_slice) {
             return Result::Err(MemoryError::OutOfBoundsError);
         }
-        return Result::Ok(memory_slice.values[index].clone());
+        Result::Ok(memory_slice.values[index].clone())
     }
 
     pub fn get_reference_to_single_value<'a>(
@@ -299,19 +299,19 @@ impl<C: Clone> MemorySlice<C> {
         let cell = MemorySlice::get_initial_cell(memory_slice, access)?;
         Result::Ok(&memory_slice.values[cell])
     }
-    pub fn get_reference_to_single_value_by_index<'a>(
-        memory_slice: &'a MemorySlice<C>,
+    pub fn get_reference_to_single_value_by_index(
+        memory_slice: &MemorySlice<C>,
         index: usize,
-    ) -> Result<&'a C, MemoryError> {
+    ) -> Result<&C, MemoryError> {
         if index > MemorySlice::get_number_of_cells(memory_slice) {
             return Result::Err(MemoryError::OutOfBoundsError);
         }
         Result::Ok(&memory_slice.values[index])
     }
-    pub fn get_reference_to_single_value_by_index_or_break<'a>(
-        memory_slice: &'a MemorySlice<C>,
+    pub fn get_reference_to_single_value_by_index_or_break(
+        memory_slice: &MemorySlice<C>,
         index: usize,
-    ) -> &'a C {
+    ) -> &C {
         if index > MemorySlice::get_number_of_cells(memory_slice) {
             unreachable!("The index is too big for the slice");
         }
@@ -396,7 +396,7 @@ mod tests {
         let new_row = U32Slice::new_with_route(&[4], &4);
 
         let res = U32Slice::insert_values(&mut slice, &[2], &new_row, false);
-        if let Result::Ok(_) = res {
+        if res.is_ok() {
             for c in 0..4 {
                 let memory_result = U32Slice::get_reference_to_single_value(&slice, &[2, c]);
                 if let Result::Ok(val) = memory_result {

--- a/type_analysis/src/analyzers/custom_gate_analysis.rs
+++ b/type_analysis/src/analyzers/custom_gate_analysis.rs
@@ -68,20 +68,17 @@ pub fn custom_gate_analysis(
             }
             Substitution { meta, op, .. } => {
                 use AssignOp::*;
-                match op {
-                    AssignConstraintSignal => {
-                        let mut error = Report::error(
-                            String::from("Added constraint inside custom template"),
-                            ReportCode::CustomGateConstraintError
-                        );
-                        error.add_primary(
-                            meta.location.clone(),
-                            meta.file_id.unwrap(),
-                            String::from("Added constraint")
-                        );
-                        errors.push(error);
-                    }
-                    _ => {}
+                if op == &AssignConstraintSignal {
+                    let mut error = Report::error(
+                        String::from("Added constraint inside custom template"),
+                        ReportCode::CustomGateConstraintError,
+                    );
+                    error.add_primary(
+                        meta.location.clone(),
+                        meta.file_id.unwrap(),
+                        String::from("Added constraint"),
+                    );
+                    errors.push(error);
                 }
             }
             ConstraintEquality { meta, .. } => {
@@ -103,20 +100,17 @@ pub fn custom_gate_analysis(
             }
             UnderscoreSubstitution { meta, op, .. } => {
                 use AssignOp::*;
-                match op {
-                    AssignConstraintSignal => {
-                        let mut error = Report::error(
-                            String::from("Added constraint inside custom template"),
-                            ReportCode::CustomGateConstraintError
-                        );
-                        error.add_primary(
-                            meta.location.clone(),
-                            meta.file_id.unwrap(),
-                            String::from("Added constraint")
-                        );
-                        errors.push(error);
-                    }
-                    _ => {}
+                if op == &AssignConstraintSignal {
+                    let mut error = Report::error(
+                        String::from("Added constraint inside custom template"),
+                        ReportCode::CustomGateConstraintError,
+                    );
+                    error.add_primary(
+                        meta.location.clone(),
+                        meta.file_id.unwrap(),
+                        String::from("Added constraint"),
+                    );
+                    errors.push(error);
                 }
             }
             _ => {}

--- a/type_analysis/src/analyzers/functions_all_paths_with_return_statement.rs
+++ b/type_analysis/src/analyzers/functions_all_paths_with_return_statement.rs
@@ -3,14 +3,14 @@ use program_structure::error_code::ReportCode;
 use program_structure::error_definition::Report;
 use program_structure::function_data::FunctionData;
 
-pub fn all_paths_with_return_check(function_data: &FunctionData) -> Result<(), Report> {
+pub fn all_paths_with_return_check(function_data: &FunctionData) -> Result<(), Box<Report>> {
     let function_body = function_data.get_body();
     let function_name = function_data.get_name();
     if !analyse_statement(function_body) {
-        return Result::Err(Report::error(
+        return Result::Err(Box::new(Report::error(
             format!("In {} there are paths without return", function_name),
             ReportCode::FunctionReturnError,
-        ));
+        )));
     }
     Result::Ok(())
 }
@@ -31,7 +31,7 @@ fn analyse_statement(stmt: &Statement) -> bool {
     }
 }
 
-fn analyse_block(block: &Vec<Statement>) -> bool {
+fn analyse_block(block: &[Statement]) -> bool {
     let mut has_return_path = false;
     for stmt in block.iter() {
         has_return_path = has_return_path || analyse_statement(stmt);

--- a/type_analysis/src/analyzers/functions_free_of_template_elements.rs
+++ b/type_analysis/src/analyzers/functions_free_of_template_elements.rs
@@ -92,12 +92,12 @@ fn analyse_statement(
         }
         ConstraintEquality { meta, lhe, rhe, .. } => {
             let mut report = Report::error(
-                format!("Function uses template operators"),
+                "Function uses template operators".to_string(),
                 ReportCode::UndefinedFunction,
             );
             let location =
                 file_definition::generate_file_location(meta.get_start(), meta.get_end());
-            report.add_primary(location, file_id.clone(), format!("Template operator found"));
+            report.add_primary(location, file_id, "Template operator found".to_string());
             reports.push(report);
             analyse_expression(lhe, function_names, reports);
             analyse_expression(rhe, function_names, reports);
@@ -143,12 +143,12 @@ fn analyse_access(
             analyse_expression(index, function_names, reports);
         } else {
             let mut report = Report::error(
-                format!("Function uses component operators"),
+                "Function uses component operators".to_string(),
                 ReportCode::UndefinedFunction,
             );
             let location =
                 file_definition::generate_file_location(meta.get_start(), meta.get_end());
-            report.add_primary(location, file_id.clone(), format!("Template operator found"));
+            report.add_primary(location, file_id, "Template operator found".to_string());
             reports.push(report);
         }
     }
@@ -182,12 +182,12 @@ fn analyse_expression(
         Call { meta, id, args, .. } => {
             if !function_names.contains(id) {
                 let mut report = Report::error(
-                    format!("Unknown call in function"),
+                    "Unknown call in function".to_string(),
                     ReportCode::UndefinedFunction,
                 );
                 let location =
                     file_definition::generate_file_location(meta.get_start(), meta.get_end());
-                report.add_primary(location, file_id.clone(), format!("Is not a function call"));
+                report.add_primary(location, file_id, "Is not a function call".to_string());
                 reports.push(report);
             }
             for arg in args.iter() {

--- a/type_analysis/src/analyzers/functions_free_of_template_elements.rs
+++ b/type_analysis/src/analyzers/functions_free_of_template_elements.rs
@@ -132,7 +132,7 @@ fn analyse_statement(
 }
 
 fn analyse_access(
-    access: &Vec<Access>,
+    access: &[Access],
     meta: &Meta,
     function_names: &HashSet<String>,
     reports: &mut ReportCollection,

--- a/type_analysis/src/analyzers/no_returns_in_template.rs
+++ b/type_analysis/src/analyzers/no_returns_in_template.rs
@@ -8,7 +8,7 @@ pub fn free_of_returns(template_data: &TemplateData) -> Result<(), ReportCollect
     let file_id = template_data.get_file_id();
     let template_body = template_data.get_body();
     let mut reports = ReportCollection::new();
-    look_for_return(&template_body, file_id, &mut reports);
+    look_for_return(template_body, file_id, &mut reports);
     if reports.is_empty() {
         Result::Ok(())
     } else {

--- a/type_analysis/src/analyzers/signal_declaration_analysis.rs
+++ b/type_analysis/src/analyzers/signal_declaration_analysis.rs
@@ -51,7 +51,7 @@ fn treat_statement(
                         file_definition::generate_file_location(meta.get_start(), meta.get_end());
                     report.add_primary(
                         location,
-                        template_id.clone(),
+                        template_id,
                         "Is outside the initial scope".to_string(),
                     );
                     reports.push(report);

--- a/type_analysis/src/analyzers/symbol_analysis.rs
+++ b/type_analysis/src/analyzers/symbol_analysis.rs
@@ -14,7 +14,7 @@ pub fn check_naming_correctness(program_archive: &ProgramArchive) -> Result<(), 
     let function_info = program_archive.get_functions();
     let mut reports = ReportCollection::new();
     let mut instances = Vec::new();
-    for (_, data) in template_info {
+    for data in template_info.values() {
         let instance = (
             data.get_file_id(),
             data.get_param_location(),
@@ -23,7 +23,7 @@ pub fn check_naming_correctness(program_archive: &ProgramArchive) -> Result<(), 
         );
         instances.push(instance);
     }
-    for (_, data) in function_info {
+    for data in function_info.values() {
         let instance = (
             data.get_file_id(),
             data.get_param_location(),
@@ -269,10 +269,11 @@ fn analyze_statement(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn treat_variable(
     meta: &Meta,
     name: &String,
-    access: &Vec<Access>,
+    access: &[Access],
     file_id: FileID,
     function_info: &FunctionInfo,
     template_info: &TemplateInfo,

--- a/type_analysis/src/analyzers/symbol_analysis.rs
+++ b/type_analysis/src/analyzers/symbol_analysis.rs
@@ -68,7 +68,7 @@ fn analyze_main(program: &ProgramArchive) -> Result<(), Vec<Report>> {
             for signal in signals {
                 if !inputs.contains_key(signal) {
                     let mut report = Report::error(
-                        format!("Invalid public list"),
+                        "Invalid public list".to_string(),
                         ReportCode::SameSymbolDeclaredTwice,
                     );
                     report.add_primary(
@@ -112,11 +112,11 @@ pub fn analyze_symbols(
     }
     if param_name_collision {
         let mut report =
-            Report::error(format!("Symbol declared twice"), ReportCode::SameSymbolDeclaredTwice);
+            Report::error("Symbol declared twice".to_string(), ReportCode::SameSymbolDeclaredTwice);
         report.add_primary(
             param_location.clone(),
-            file_id.clone(),
-            format!("Declaring same symbol twice"),
+            file_id,
+            "Declaring same symbol twice".to_string(),
         );
         reports.push(report);
     }
@@ -213,13 +213,13 @@ fn analyze_statement(
             }
             if !add_symbol_to_block(environment, name) {
                 let mut report = Report::error(
-                    format!("Symbol declared twice"),
+                    "Symbol declared twice".to_string(),
                     ReportCode::SameSymbolDeclaredTwice,
                 );
                 report.add_primary(
                     meta.location.clone(),
-                    file_id.clone(),
-                    format!("Declaring same symbol twice"),
+                    file_id,
+                    "Declaring same symbol twice".to_string(),
                 );
                 reports.push(report);
             }
@@ -280,11 +280,11 @@ fn treat_variable(
     environment: &Environment,
 ) {
     if !symbol_in_environment(environment, name) {
-        let mut report = Report::error(format!("Undeclared symbol"), ReportCode::NonExistentSymbol);
+        let mut report = Report::error("Undeclared symbol".to_string(), ReportCode::NonExistentSymbol);
         report.add_primary(
             file_definition::generate_file_location(meta.get_start(), meta.get_end()),
-            file_id.clone(),
-            format!("Using unknown symbol"),
+            file_id,
+            "Using unknown symbol".to_string(),
         );
         reports.push(report);
     }
@@ -346,11 +346,11 @@ fn analyze_expression(
         Expression::Call { meta, id, args, .. } => {
             if !function_info.contains_key(id) && !template_info.contains_key(id) {
                 let mut report =
-                    Report::error(format!("Calling symbol"), ReportCode::NonExistentSymbol);
+                    Report::error("Calling symbol".to_string(), ReportCode::NonExistentSymbol);
                 report.add_primary(
                     file_definition::generate_file_location(meta.get_start(), meta.get_end()),
-                    file_id.clone(),
-                    format!("Calling unknown symbol"),
+                    file_id,
+                    "Calling unknown symbol".to_string(),
                 );
                 reports.push(report);
                 return;
@@ -362,12 +362,12 @@ fn analyze_expression(
             };
             if args.len() != expected_num_of_params {
                 let mut report = Report::error(
-                    format!("Calling function with wrong number of arguments"),
+                    "Calling function with wrong number of arguments".to_string(),
                     ReportCode::FunctionWrongNumberOfArguments,
                 );
                 report.add_primary(
                     file_definition::generate_file_location(meta.get_start(), meta.get_end()),
-                    file_id.clone(),
+                    file_id,
                     format!("Got {} params, {} where expected", args.len(), expected_num_of_params),
                 );
                 reports.push(report);

--- a/type_analysis/src/analyzers/type_check.rs
+++ b/type_analysis/src/analyzers/type_check.rs
@@ -523,13 +523,7 @@ fn type_expression(
                 );
             };
             let dim_type = type_expression(dimension, program_archive, analysis_information)?;
-            if dim_type.is_template() {
-                add_report(
-                    ReportCode::InvalidArrayType,
-                    expression.get_meta(),
-                    &mut analysis_information.reports,
-                );
-            } else if dim_type.dim() != 0 {
+            if dim_type.is_template() || dim_type.dim() != 0{
                 add_report(
                     ReportCode::InvalidArrayType,
                     expression.get_meta(),

--- a/type_analysis/src/analyzers/type_check.rs
+++ b/type_analysis/src/analyzers/type_check.rs
@@ -344,7 +344,7 @@ fn type_statement(
         LogCall { args, meta } => {
             for arglog in args {
                 if let LogArgument::LogExp(arg) = arglog{
-                    let arg_response = type_expression(&arg, program_archive, analysis_information);
+                    let arg_response = type_expression(arg, program_archive, analysis_information);
                     let arg_type = if let Result::Ok(t) = arg_response {
                         t
                     } else {
@@ -395,7 +395,7 @@ fn type_statement(
             } else {
                 return;
             };
-            let ret_type = analysis_information.return_type.clone().unwrap();
+            let ret_type = analysis_information.return_type.unwrap();
             debug_assert!(!value_type.is_template());
             if ret_type != value_type.dim() {
                 add_report(
@@ -702,7 +702,7 @@ fn type_expression(
                 std::mem::replace(&mut analysis_information.environment, new_environment);
             let returned_type = if program_archive.contains_function(id) {
                 type_function(id, &concrete_types, meta, analysis_information, program_archive)
-                    .map(|val| FoldedType::arithmetic_type(val))
+                    .map(FoldedType::arithmetic_type)
             } else {
                 let r_val =
                     type_template(id, &concrete_types, analysis_information, program_archive);
@@ -743,7 +743,7 @@ fn treat_access(
     for access in accesses {
         match access {
             ArrayAccess(index) => {
-                let index_response = type_expression(&index, program_archive, analysis_information);
+                let index_response = type_expression(index, program_archive, analysis_information);
                 
                 if access_info.2.is_some(){
                     add_report(
@@ -847,7 +847,7 @@ fn apply_access_to_symbol(
             };
             if access_information.2.is_some(){ // tag of io signal of component
                 if dims_accessed > 0{
-                    return add_report_and_end(ReportCode::InvalidTagAccessAfterArray, meta, reports);
+                    add_report_and_end(ReportCode::InvalidTagAccessAfterArray, meta, reports)
                 }
                 else if !tags.contains(&access_information.2.unwrap()){
                     return add_report_and_end(ReportCode::InvalidTagAccess, meta, reports);
@@ -856,9 +856,9 @@ fn apply_access_to_symbol(
                 }
             } else{ // io signal of component
                 if dims_accessed > current_dim {
-                    return add_report_and_end(ReportCode::InvalidArrayAccess(current_dim, dims_accessed), meta, reports);
+                    add_report_and_end(ReportCode::InvalidArrayAccess(current_dim, dims_accessed), meta, reports)
                 } else {
-                    return Result::Ok(SymbolInformation::Signal(current_dim - dims_accessed));
+                    Result::Ok(SymbolInformation::Signal(current_dim - dims_accessed))
                 }   
             }
         } else{ // we are in template
@@ -1035,10 +1035,10 @@ fn add_report(error_code: ReportCode, meta: &Meta, reports: &mut ReportCollectio
         InvalidPartialArray => "Only variable arrays can be accessed partially".to_string(),
         UninitializedSymbolInExpression => "The type of this symbol is not known".to_string(),
         WrongTypesInAssignOperationOperatorSignal => {
-            format!("The operator does not match the types of the assigned elements.\n Assignments to signals do not allow the operator =, try using <== or <-- instead")
+            "The operator does not match the types of the assigned elements.\n Assignments to signals do not allow the operator =, try using <== or <-- instead".to_string()
         }
         WrongTypesInAssignOperationOperatorNoSignal => {
-            format!("The operator does not match the types of the assigned elements.\n Only assignments to signals allow the operators <== and <--, try using = instead")
+            "The operator does not match the types of the assigned elements.\n Only assignments to signals allow the operators <== and <--, try using = instead".to_string()
         }
         WrongTypesInAssignOperationArrayTemplates => "Assignee and assigned types do not match.\n All components of an array must be instances of the same template.".to_string(),
         WrongTypesInAssignOperationTemplate => "Assignee and assigned types do not match.\n Expected template found expression.".to_string(),
@@ -1053,7 +1053,7 @@ fn add_report(error_code: ReportCode, meta: &Meta, reports: &mut ReportCollectio
             format!("Must be a single arithmetic expression.\n Found expression of {} dimensions", dim)
         }
         MustBeSingleArithmeticT => {
-              format!("Must be a single arithmetic expression.\n Found component")
+              "Must be a single arithmetic expression.\n Found component".to_string()
         }
         MustBeArithmetic => "Must be a single arithmetic expression or an array of arithmetic expressions. \n Found component".to_string(),
         OutputTagCannotBeModifiedOutside => "Output tag from a subcomponent cannot be modified".to_string(),

--- a/type_analysis/src/analyzers/type_given_function.rs
+++ b/type_analysis/src/analyzers/type_given_function.rs
@@ -134,7 +134,6 @@ fn look_for_return_in_statement(
             function_name,
             environment,
             explored_functions,
-            function_data,
             function_info,
             value,
         ),
@@ -173,7 +172,7 @@ fn look_for_return_in_block(
     explored_functions: &mut NodeRegister,
     function_data: &FunctionData,
     function_info: &HashMap<String, FunctionData>,
-    stmts: &Vec<Statement>,
+    stmts: &[Statement],
 ) -> Option<Type> {
     environment.push(Block::new());
     for stmt in stmts.iter() {
@@ -198,7 +197,6 @@ fn look_for_type_in_expression(
     function_name: &str,
     environment: &mut Environment,
     explored_functions: &mut NodeRegister,
-    function_data: &FunctionData,
     function_info: &HashMap<String, FunctionData>,
     expression: &Expression,
 ) -> Option<Type> {
@@ -208,7 +206,6 @@ fn look_for_type_in_expression(
                 function_name,
                 environment,
                 explored_functions,
-                function_data,
                 function_info,
                 lhe,
             );
@@ -220,7 +217,6 @@ fn look_for_type_in_expression(
                 function_name,
                 environment,
                 explored_functions,
-                function_data,
                 function_info,
                 rhe,
             )
@@ -229,7 +225,6 @@ fn look_for_type_in_expression(
             function_name,
             environment,
             explored_functions,
-            function_data,
             function_info,
             rhe,
         ),
@@ -237,7 +232,6 @@ fn look_for_type_in_expression(
             function_name,
             environment,
             explored_functions,
-            function_data,
             function_info,
             rhe,
         ),
@@ -246,7 +240,6 @@ fn look_for_type_in_expression(
                 function_name,
                 environment,
                 explored_functions,
-                function_data,
                 function_info,
                 if_true,
             );
@@ -258,7 +251,6 @@ fn look_for_type_in_expression(
                 function_name,
                 environment,
                 explored_functions,
-                function_data,
                 function_info,
                 if_false,
             )
@@ -276,7 +268,6 @@ fn look_for_type_in_expression(
             function_name,
             environment,
             explored_functions,
-            function_data,
             function_info,
             &values[0],
         )
@@ -286,17 +277,10 @@ fn look_for_type_in_expression(
                 function_name,
                 environment,
                 explored_functions,
-                function_data,
                 function_info,
                 value,
             );
-            if value_type.is_some(){
-                Option::Some(value_type.unwrap() + 1)
-            }
-            else{
-                None
-            }
-            
+            value_type.map(|x| x + 1)
         }
         Expression::Call { id, args, .. } => {
             if explored_functions.contains(id) {
@@ -308,7 +292,6 @@ fn look_for_type_in_expression(
                     function_name,
                     environment,
                     explored_functions,
-                    function_data,
                     function_info,
                     arg,
                 )?;

--- a/type_analysis/src/analyzers/type_register.rs
+++ b/type_analysis/src/analyzers/type_register.rs
@@ -29,12 +29,7 @@ impl<Type: Default + Eq> TypeRegister<Type> {
             return Option::None;
         }
         let instances = self.id_to_instances.get(id).unwrap();
-        for instance in instances {
-            if instance.arguments() == look_for {
-                return Option::Some(&instance);
-            }
-        }
-        Option::None
+        instances.iter().find(|&instance| instance.arguments() == look_for)
     }
     pub fn add_instance(
         &mut self,

--- a/type_analysis/src/analyzers/unknown_known_analysis.rs
+++ b/type_analysis/src/analyzers/unknown_known_analysis.rs
@@ -338,12 +338,10 @@ fn tag(expression: &Expression, environment: &Environment) -> Tag {
                 *environment.get_variable_or_break(name, file!(), line!())
             } else if environment.has_component(name) {
                 *environment.get_component_or_break(name, file!(), line!())
-            } else {
-                if environment.has_intermediate(name) && !all_array_are_accesses(access) {
-                    Known /* In this case, it is a tag. */
-                } else{
-                *environment.get_intermediate_or_break(name, file!(), line!())
-                }
+            } else if environment.has_intermediate(name) && !all_array_are_accesses(access) {
+                Known /* In this case, it is a tag. */
+            } else{
+            *environment.get_intermediate_or_break(name, file!(), line!())
             };
             let mut index = 0;
             loop {
@@ -416,7 +414,7 @@ fn all_array_are_accesses(accesses: &[Access]) -> bool {
         if let Access::ComponentAccess(_) = aux {
             all_array_accesses = false;
         }
-        i = i + 1;
+        i += 1;
     }
     all_array_accesses
 }
@@ -518,7 +516,7 @@ fn unknown_index(exp: &Expression, environment: &Environment) -> bool {
         if index == rec.len() || has_unknown_index {
             break has_unknown_index;
         }
-        has_unknown_index = unknown_index(&rec[index], environment);
+        has_unknown_index = unknown_index(rec[index], environment);
         index += 1;
     }
 }

--- a/type_analysis/src/check_types.rs
+++ b/type_analysis/src/check_types.rs
@@ -108,7 +108,7 @@ fn function_level_analyses(program_archive: &ProgramArchive, reports: &mut Repor
             reports.append(&mut functions_free_of_template_elements_reports);
         }
         if let Result::Err(functions_all_paths_with_return_statement_report) = result_1 {
-            reports.push(functions_all_paths_with_return_statement_report);
+            reports.push(*functions_all_paths_with_return_statement_report);
         }
     }
 }


### PR DESCRIPTION
- Applied fixes suggested by "cargo clippy"
- A few of the suggestions were ignored by adding "allow" annotations to avoid changing public interfaces. These can be revisited in the future to assess the impact of minor changes to public interfaces.
- Box::clone followed by immediate de-reference is changed to first reference the value out of the box and clone only that value to avoid cloning the Box itself.
- Also a few other minor formatting changes and code simplifications.
