### PR TITLE
Fix calcwit.cpp InputHashMap wrap-around

### DIFF
--- a/code_producers/src/c_elements/common/calcwit.cpp
+++ b/code_producers/src/c_elements/common/calcwit.cpp
@@ -52,14 +52,14 @@ uint Circom_CalcWit::getInputSignalHashPosition(u64 h) {
   uint pos = (uint)(h % (u64)n);
   if (circuit->InputHashMap[pos].hash!=h){
     uint inipos = pos;
-    pos++;
+    pos = (pos+1)%n;
     while (pos != inipos) {
       if (circuit->InputHashMap[pos].hash==h) return pos;
       if (circuit->InputHashMap[pos].hash==0) {
 	fprintf(stderr, "Signal not found\n");
 	assert(false);
       }
-      pos = (pos+1)%n; 
+      pos = (pos+1)%n;
     }
     fprintf(stderr, "Signals not found\n");
     assert(false);


### PR DESCRIPTION
The witness calculated generated with `circom --cpp` may not work depending on the input signal names.

In the calcwit.cpp, if the signal name hash `h` happens to satisfy `pos = (h % 256) = get_size_of_input_hashmap() - 1` and there is a hashmap collision, then the loop fails to find the InputHashMap entry.

This PR fixes the edge case.