### PR TITLE
fix:constraint-generation doc

### DIFF
--- a/mkdocs/docs/circom-language/constraint-generation.md
+++ b/mkdocs/docs/circom-language/constraint-generation.md
@@ -30,8 +30,8 @@ out <== 1 - a*b;
 Which is equivalent to:
 
 ```text
-out === 1 – a*b;
 out <-- 1 - a*b;
+out === 1 – a*b;
 ```
 
 As mentioned before, assigning a value to a signal using `<--` and `-->` is considered dangerous and should, in general, be combined with adding constraints with `===`, which describe by means of constraints which the assigned values are. For example:


### PR DESCRIPTION

The `<== `operator  seems first assigns, then adds a constraint.