### PR TITLE
Make some types public to use Circom as a library

### DIFF
--- a/compiler/src/intermediate_representation/address_type.rs
+++ b/compiler/src/intermediate_representation/address_type.rs
@@ -13,6 +13,22 @@ pub enum InputInformation {
     Input {status: StatusInput},
 }
 
+impl ToString for InputInformation {
+    fn to_string(&self) -> String {
+        use InputInformation::*;
+        match self {
+            NoInput => "NO_INPUT".to_string(),
+            Input { status } => {
+                match status {
+                    StatusInput::Last => "LAST".to_string(),
+                    StatusInput::NoLast => "NO_LAST".to_string(),
+                    StatusInput::Unknown => "UNKNOWN".to_string(),
+                }
+            }
+        }
+    }
+}
+
 #[derive(Clone)]
 pub enum AddressType {
     Variable,
@@ -26,7 +42,7 @@ impl ToString for AddressType {
         match self {
             Variable => "VARIABLE".to_string(),
             Signal => "SIGNAL".to_string(),
-            SubcmpSignal { cmp_address, .. } => format!("SUBCOMPONENT:{}", cmp_address.to_string()),
+            SubcmpSignal { cmp_address, input_information, .. } => format!("SUBCOMPONENT:{}:{}", cmp_address.to_string(), input_information.to_string()),
         }
     }
 }

--- a/compiler/src/intermediate_representation/branch_bucket.rs
+++ b/compiler/src/intermediate_representation/branch_bucket.rs
@@ -46,7 +46,7 @@ impl ToString for BranchBucket {
             else_body = format!("{}{};", else_body, i.to_string());
         }
         format!(
-            "IF(line:{},template_id:{},cond:{},if:{},else{})",
+            "IF(line:{},template_id:{},cond:{},if:{},else:{})",
             line, template_id, cond, if_body, else_body
         )
     }

--- a/compiler/src/intermediate_representation/compute_bucket.rs
+++ b/compiler/src/intermediate_representation/compute_bucket.rs
@@ -3,7 +3,7 @@ use crate::translating_traits::*;
 use code_producers::c_elements::*;
 use code_producers::wasm_elements::*;
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum OperatorType {
     Mul,
     Div,

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,6 +1,6 @@
 #[allow(dead_code)]
-mod circuit_design;
-mod intermediate_representation;
+pub mod circuit_design;
+pub mod intermediate_representation;
 mod ir_processing;
 pub extern crate num_bigint_dig as num_bigint;
 pub extern crate num_traits;

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -13,7 +13,7 @@ num-traits = "0.2.6"
 
 [dependencies]
 program_structure = {path = "../program_structure"}
-lalrpop-util = "0.19.9"
+lalrpop-util = { version="0.19.9",  features = ["lexer"]}
 regex = "1.1.2"
 rustc-hex = "2.0.1"
 num-bigint-dig = "0.6.0"


### PR DESCRIPTION
To use Circom as a library from https://github.com/iden3/circom-witnesscalc, it would be great to make few types public. And add a lexer feature to `lalrpop-util`

Also I've fixed some issuers with formatting of internal structs. 

And make OperatorType hashable to be able to use it as a Key in Map.