### PR TITLE
remove `await` before _doCalculateWitness()

### DIFF
--- a/code_producers/src/wasm_elements/common/witness_calculator.js
+++ b/code_producers/src/wasm_elements/common/witness_calculator.js
@@ -179,7 +179,7 @@ class WitnessCalculator {
     async calculateWitness(input, sanityCheck) {
 
         const w = [];
-        await this._doCalculateWitness(input, sanityCheck);
+        this._doCalculateWitness(input, sanityCheck);
 
         for (let i=0; i<this.witnessSize; i++) {
             this.instance.exports.getWitness(i);
@@ -198,7 +198,7 @@ class WitnessCalculator {
 
         const buff32 = new Uint32Array(this.witnessSize*this.n32);
 	const buff = new  Uint8Array( buff32.buffer);
-        await this._doCalculateWitness(input, sanityCheck);
+        this._doCalculateWitness(input, sanityCheck);
 
         for (let i=0; i<this.witnessSize; i++) {
             this.instance.exports.getWitness(i);
@@ -216,7 +216,7 @@ class WitnessCalculator {
 
         const buff32 = new Uint32Array(this.witnessSize*this.n32+this.n32+11);
 	const buff = new  Uint8Array( buff32.buffer);
-        await this._doCalculateWitness(input, sanityCheck);
+        this._doCalculateWitness(input, sanityCheck);
   
 	//"wtns"
 	buff[0] = "w".charCodeAt(0)


### PR DESCRIPTION
Ensure that the generate witness operation within the same function does not retrieve incorrect data when running concurrent code with promises, because the WASM side uses the same instance and memory.

This is a minimal change that ensures the functions calculateWTNSBin(), calculateBinWitness(), and calculateWitness() maintain their original async interfaces.

close https://github.com/iden3/circom/issues/297