### PR TITLE
Update the binaries GitHub workflow to add support for ARM builds

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -7,34 +7,69 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: write
+
 jobs:
   build-and-publish:
-    name: Publish for ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.platform.os_name }} with rust ${{ matrix.toolchain }}
+    runs-on: ${{ matrix.platform.os }}
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            artifact_name: circom
-            asset_name: circom-linux-amd64
-          - os: windows-latest
-            artifact_name: circom.exe
-            asset_name: circom-windows-amd64.exe
-          - os: macos-latest
-            artifact_name: circom
-            asset_name: circom-macos-amd64
-
+        platform:
+          - os_name: Linux-aarch64
+            os: ubuntu-20.04
+            target: aarch64-unknown-linux-musl
+            bin: circom-linux-arm64
+          - os_name: Linux-x86_64
+            os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            bin: circom-linux-amd64
+          - os_name: Windows-x86_64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            bin: circom-amd64.exe
+          - os_name: Windows-aarch64
+            os: windows-latest
+            target: aarch64-pc-windows-msvc
+            bin: circom-arm64.exe
+          - os_name: macOS-x86_64
+            os: macOS-latest
+            target: x86_64-apple-darwin
+            bin: circom-darwin-amd64
+          - os_name: macOS-aarch64
+            os: macOS-latest
+            target: aarch64-apple-darwin
+            bin: circom-darwin-arm64
+        toolchain:
+          - stable
     steps:
-      - name: Checkout project
-        uses: actions/checkout@v2
-
-      - name: Build
-        run: cargo build --verbose --release
-
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
+      - uses: actions/checkout@v3
+      - name: Build binary
+        uses: houseabsolute/actions-rust-cross@v0
         with:
-          file: target/release/${{ matrix.artifact_name }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }}
-          asset_name: ${{ matrix.asset_name }}
+          command: "build"
+          target: ${{ matrix.platform.target }}
+          toolchain: ${{ matrix.toolchain }}
+          args: "--locked --release"
+          strip: true
+
+      - name: Rename binary (linux and macos)
+        run: mv target/${{ matrix.platform.target }}/release/circom target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }}
+        if: matrix.platform.os_name != 'Windows-x86_64' && matrix.platform.os_name != 'Windows-aarch64'
+
+      - name: Rename binary (windows)
+        run: mv target/${{ matrix.platform.target }}/release/circom.exe target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }}
+        if: matrix.platform.os_name == 'Windows-x86_64' || matrix.platform.os_name == 'Windows-aarch64'
+
+      - name: Generate SHA-256
+        run: shasum -a 256 target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }} | cut -d ' ' -f 1 > target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }}.sha256
+
+      - name: Release binary and SHA-256 checksum to GitHub
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }}
+            target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }}.sha256


### PR DESCRIPTION
Currently, the CI does not support building binaries for ARM machines. This PR fixes the issue

ARM executables are much more faster on systems where ARM chips are used, e.g., Macs with M series

We have tested the CI here: https://github.com/distributed-lab/circom/releases/tag/v2.1.9