### PR TITLE
Fix typos in documentation

### DIFF
--- a/mkdocs/docs/background/background.md
+++ b/mkdocs/docs/background/background.md
@@ -109,5 +109,5 @@ An assignment of the signals is called a **witness**. For example, `{a = 2, b = 
 
 ## Summary <a id="summary"></a>
 
-​**In summary, zk-SNARK proofs are an specific type of zero-knowledge proofs that allow you to prove that you know a set of signals (witness) that match all the constraints of a circuit without revealing any of the signals except the public inputs and the outputs.**
+​**In summary, zk-SNARK proofs are a specific type of zero-knowledge proofs that allow you to prove that you know a set of signals (witness) that match all the constraints of a circuit without revealing any of the signals except the public inputs and the outputs.**
 

--- a/mkdocs/docs/circom-language/anonymous-components-and-tuples.md
+++ b/mkdocs/docs/circom-language/anonymous-components-and-tuples.md
@@ -72,7 +72,7 @@ component main = B(2);
 
 The value returned by the anonymous components depends on the number of template's output signals.
 
-1. __If the template does not define any output signal__ (for instance, if it only defines constraints based on the input signals),  we can use the anonymous component like if it was an statement 
+1. __If the template does not define any output signal__ (for instance, if it only defines constraints based on the input signals),  we can use the anonymous component like if it was a statement 
    `temp_name(arg1,...,argN)(inp1,...,inpM);`
 
 2. __If the template defines a single output signal__, we can use any of the well-known operators to collect the output signal. It is important to highlight that we can use with the anonymous components any of the operators `<==`, `==>` and `=`  with the usual semantics, but not `<--` and `-->`, since there is no way to add additional constraints including the signals of the anonymous components (which will end up in security issues in most of the cases). For instance,

--- a/program_structure/src/utils/memory_slice.rs
+++ b/program_structure/src/utils/memory_slice.rs
@@ -38,7 +38,7 @@ pub enum MemoryError {
 pub type SliceCapacity = usize;
 pub type SimpleSlice = MemorySlice<BigInt>;
 /*
-    Represents the value stored in a element of a circom program.
+    Represents the value stored in an element of a circom program.
     The attribute route stores the dimensions of the slice, used to navigate through them.
     The length of values is equal to multiplying all the values in route.
 */

--- a/type_analysis/src/decorators/constants_handler.rs
+++ b/type_analysis/src/decorators/constants_handler.rs
@@ -228,7 +228,7 @@ fn block_invariant_check(stmts: &[Statement], environment: &mut Constants) -> Re
     reports
 }
 
-// Set of functions whose purpose is to determine if a expression is constant or not under some environment
+// Set of functions whose purpose is to determine if an expression is constant or not under some environment
 fn has_constant_value(expr: &Expression, environment: &Constants) -> bool {
     use Expression::*;
     match expr {


### PR DESCRIPTION
This pull request addresses several minor typographical errors in both documentation and source code files to improve clarity and readability.

### Files Updated:
1. **background.md**: Corrected "an specific" to "a specific."
2. **anonymous-components-and-tuples.md**: Replaced "an statement" with "a statement."
3. **memory_slice.rs**: Fixed "a element" to "an element."
4. **constants_handler.rs**: Changed "a expression" to "an expression."