### PR TITLE
chore: fix quotation marks

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -258,7 +258,7 @@
 
 #### Extensions
 -	A check that all inputs are set is added in the wasm/JS and C++ generated code.
--	Improvement of the “merge_code” implementation in code generators. 
+-	Improvement of the "merge_code" implementation in code generators. 
 
 ## Nov 9, 2021 circom 2.0.1
 

--- a/mkdocs/docs/circom-language/control-flow.md
+++ b/mkdocs/docs/circom-language/control-flow.md
@@ -6,7 +6,7 @@ We have standard constructions for defining the control flow of the program.
 
 **if ( boolean_condition ) block_of_code else block_of_code**
 
-The else part is optional. When omitted, it means “else do nothing”.
+The else part is optional. When omitted, it means "else do nothing".
 
 ```text
 var x = 0;

--- a/mkdocs/docs/circom-language/identifiers.md
+++ b/mkdocs/docs/circom-language/identifiers.md
@@ -1,6 +1,6 @@
 # Identifiers
 
-Any non-reserved keyword that starts with any number of “\__” followed by an ASCII alphabetic character and followed by any number of alphabetic or numeric chars, “\_”_ or “$” can be used as identifier. Examples of identifiers are the following:
+Any non-reserved keyword that starts with any number of "\__" followed by an ASCII alphabetic character and followed by any number of alphabetic or numeric chars, "\_"_ or "$" can be used as identifier. Examples of identifiers are the following:
 
 ```text
 signal input _in; 

--- a/mkdocs/docs/circom-language/the-main-component.md
+++ b/mkdocs/docs/circom-language/the-main-component.md
@@ -1,6 +1,6 @@
 # The Main Component
 
-In order to start the execution, an initial component has to be given. By default, the name of this component is “main”, and hence the component main needs to be instantiated with some template.
+In order to start the execution, an initial component has to be given. By default, the name of this component is "main", and hence the component main needs to be instantiated with some template.
 
 This is a special initial component needed to create a circuit and it defines the global input and output signals of a circuit. For this reason, compared to the other components, it has a special attribute: the list of public input signals. The syntax of the creation of the main component is:
 


### PR DESCRIPTION
The unexpected marks might confuse readers and be distracted by them. Also some editors might not render correctly depending on the software or platform used, appearing as gibberish or causing formatting problems.