### PR TITLE
fix the usize underflowing

### DIFF
--- a/constraint_list/src/constraint_simplification.rs
+++ b/constraint_list/src/constraint_simplification.rs
@@ -590,7 +590,7 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
         crate::state_utils::empty_encoding_constraints(&mut smp.dag_encoding);
         let _dur = now.elapsed().unwrap().as_millis();
         // println!("Storages built in {} ms", dur);
-        no_rounds -= 1;
+        no_rounds.saturating_sub(1);
         (with_linear, storage)
     };
 
@@ -637,7 +637,7 @@ pub fn simplification(smp: &mut Simplifier) -> (ConstraintStorage, SignalMap, us
             &field,
         );
         round_id += 1;
-        no_rounds -= 1;
+        no_rounds.saturating_sub(1);
         apply_round = !linear.is_empty() && no_rounds > 0;
         let _dur = now.elapsed().unwrap().as_millis();
         // println!("Iteration no {} took {} ms", round_id, dur);


### PR DESCRIPTION
this line of code: 

https://github.com/iden3/circom/blob/master/constraint_list/src/constraint_simplification.rs#L593

runs fine in release, but panics in debug mode due to an underflow. As release remove checks for under/overflows it does not detect this issue. The fix is simple: just make sure that you remain at 0 once you reach 0