### PR TITLE
chore: fix iterator reference issue in bus name loop

### DIFF
--- a/type_analysis/src/check_types.rs
+++ b/type_analysis/src/check_types.rs
@@ -166,7 +166,7 @@ fn semantic_analyses(
 ) {
     for bus_name in program_archive.get_bus_names().iter() {
         if let Result::Err(mut unknown_known_report) =
-            unknown_known_analysis(&bus_name, program_archive) {
+            unknown_known_analysis(bus_name, program_archive) {
                 errors.append(&mut unknown_known_report);
             }
     }


### PR DESCRIPTION
The loop in `program_archive.get_bus_names().iter()` produces `&&String`, leading to potential compilation issues when passed to `unknown_known_analysis`. Fixed it by dereferencing `&bus_name` to avoid double reference.