### PR TITLE
fix: correct error/warning parameter order in if-case

### DIFF
--- a/type_analysis/src/analyzers/custom_gate_analysis.rs
+++ b/type_analysis/src/analyzers/custom_gate_analysis.rs
@@ -15,7 +15,7 @@ pub fn custom_gate_analysis(
         use Statement::*;
         match stmt {
             IfThenElse { if_case, else_case, .. } => {
-                custom_gate_analysis(custom_gate_name, if_case, warnings, errors);
+                custom_gate_analysis(custom_gate_name, if_case, errors, warnings);
                 if let Some(else_case_s) = else_case {
                     custom_gate_analysis(custom_gate_name, else_case_s, errors, warnings);
                 }


### PR DESCRIPTION
I'm not entirely certain if this is a bug, but the parameter order here seems different from other function calls.