### PR TITLE
refactor(type_inference): rename variable for better clarity in infer_args function

### DIFF
--- a/compiler/src/hir/type_inference.rs
+++ b/compiler/src/hir/type_inference.rs
@@ -270,8 +270,8 @@ fn infer_args(args: &[Expression], state: &State, context: &mut SearchInfo) -> O
         if index == args.len() {
             break Option::Some(arg_types);
         }
-        let arg_type = infer_type_expresion(&args[index], state, context);
-        if let Option::Some(t) = arg_type {
+        let arg_result = infer_type_expresion(&args[index], state, context);
+        if let Option::Some(t) = arg_result {
             arg_types.push(t);
         } else {
             break Option::None;


### PR DESCRIPTION
- Renamed `arg_type` to `arg_result` in infer_args() to better reflect its purpose as function call result
- Eliminates potential naming confusion with `arg_types` array variable