### PR TITLE
docs: update dead link

### DIFF
--- a/mkdocs/docs/circom-language/code-quality/code-assertion.md
+++ b/mkdocs/docs/circom-language/code-quality/code-assertion.md
@@ -4,7 +4,7 @@
 
 This statement introduces conditions to be checked. Here, we distinguish two cases depending on if **bool_expression** is unknown at compilation time:
 
-- If the assert statement depends on a control flow with only known conditions (see [Unknowns](../circom-insight/unknowns)) and the **bool_expression** is known (e.g., if it only depends on the value of template parameters or field constants), the assert is evaluated in compilation time. If the result of the evaluation is false, then the compilation fails.  Consider the next piece of code:
+- If the assert statement depends on a control flow with only known conditions (see [Unknowns](../../circom-insight/unknowns)) and the **bool_expression** is known (e.g., if it only depends on the value of template parameters or field constants), the assert is evaluated in compilation time. If the result of the evaluation is false, then the compilation fails.  Consider the next piece of code:
 
 ```
 template A(n) {


### PR DESCRIPTION
Hi! I fixed dead link in docs
https://docs.circom.io/circom-language/code-quality/code-assertion/
![image](https://github.com/user-attachments/assets/eed8bb8e-cafd-4234-9ec3-fdd91c07243a)

404: https://docs.circom.io/circom-language/code-quality/circom-insight/unknowns
Correct: https://docs.circom.io/circom-language/circom-insight/unknowns