### PR TITLE
Add safety checks to `main_id` and improve error reporting in `map_node_to_encoding`

### DIFF
--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -503,6 +503,7 @@ impl DAG {
     }
 
     pub fn main_id(&self) -> usize {
+        assert!(!self.nodes.is_empty(), "Cannot get main_id from an empty DAG");
         self.nodes.len() - 1
     }
 

--- a/dag/src/map_to_constraint_list.rs
+++ b/dag/src/map_to_constraint_list.rs
@@ -79,8 +79,10 @@ fn map_node_to_encoding(id: usize, node: Node) -> EncodingNode {
         }
     }
 
+    let mut ordered_signals = Vec::new();
     for signal in node.ordered_signals {
-        let signal_numbering = node.signal_correspondence.get(&signal).unwrap();
+        let signal_numbering = node.signal_correspondence.get(&signal)
+            .expect(&format!("Signal name '{}' from ordered_signals not found in correspondence map", signal));
         ordered_signals.push(*signal_numbering);
     }
 


### PR DESCRIPTION
1. **Safety Assertion in `DAG::main_id`**  
   Added an `assert!` to ensure that `main_id()` is not called on an empty DAG, preventing potential panics from `.len() - 1`.  
   ```rust
   assert!(!self.nodes.is_empty(), "Cannot get main_id from an empty DAG");
   ```

2. **Improved Error Reporting in `map_node_to_encoding`**  
   Replaced `unwrap()` with `.expect()` to provide a meaningful error message when a signal from `ordered_signals` is not found in the `signal_correspondence` map:
   ```rust
   let signal_numbering = node.signal_correspondence.get(&signal)
       .expect(&format!("Signal name '{}' from ordered_signals not found in correspondence map", signal));
   ```