### PR TITLE
build: update checkout action to v4

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build
         run: cargo build --verbose --release

--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -20,7 +20,7 @@ jobs:
     # Tasks that will be executed as part of the job
     steps:
       # Checks-out repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Installs mkdocs
       - name: install mkdocs


### PR DESCRIPTION
Bumps checkout to v4 for future-proofing against Node 20 runner updates. Workflows compile the same.