### PR TITLE
fix: Fix typos in comments and error messages

### DIFF
--- a/compiler/src/intermediate_representation/call_bucket.rs
+++ b/compiler/src/intermediate_representation/call_bucket.rs
@@ -567,7 +567,7 @@ impl WriteC for CallBucket {
 			    map_prologue.push(format!("{{"));
 			    map_prologue.push(format!("uint map_accesses_aux[{}];",indexes.len().to_string()));	
 			    map_prologue.push(format!("{{"));
-			    //cur_def contains a pointer to the definion of the next acces.
+			    //cur_def contains a pointer to the definition of the next access.
 			    //The first time it is taken from template_ins_2_io_info
 			    map_prologue.push(format!("IOFieldDef *cur_def = &({}->{}[{}].defs[{}]);",
 						      circom_calc_wit(), template_ins_2_io_info(),

--- a/compiler/src/intermediate_representation/load_bucket.rs
+++ b/compiler/src/intermediate_representation/load_bucket.rs
@@ -269,7 +269,7 @@ impl WriteC for LoadBucket {
 					     template_id_in_component(sub_component_pos_in_memory.clone()),
 					     signal_code.to_string());
 	        if indexes.len() > 0 {
-		    //cur_def contains a string that goes to the definion of the next acces.
+		    //cur_def contains a string that goes to the definition of the next access.
 		    //The first time it is taken from template_ins_2_io_info
 		    let mut cur_def = format!("{}->{}[{}].defs[{}]",
 					    circom_calc_wit(), template_ins_2_io_info(),

--- a/type_analysis/src/analyzers/unknown_known_analysis.rs
+++ b/type_analysis/src/analyzers/unknown_known_analysis.rs
@@ -549,7 +549,7 @@ fn add_report(
     let mut report = Report::error("Typing error found".to_string(), error_code);
     let location = generate_file_location(meta.start, meta.end);
     let message = match error_code {
-        UnknownTemplateAssignment => "Assigments to signals within an unknown access to an array of components are not allowed".to_string(),
+        UnknownTemplateAssignment => "Assignments to signals within an unknown access to an array of components are not allowed".to_string(),
         UnknownBus => "Parameters of a bus must be known during the constraint generation phase".to_string(),
         UnknownDimension => "The length of every array must be known during the constraint generation phase".to_string(),
         UnknownTemplate => "Every component instantiation must be resolved during the constraint generation phase. This component declaration uses a value that can be unknown during the constraint generation phase.".to_string(),


### PR DESCRIPTION
This PR corrects minor typos in comments and error messages to improve code readability and clarity.
- Fixed the spelling of "definition" and "access" in comment.
- Corrected the word "Assignments" in the error message.