### PR TITLE
Fix: Replace panic with warning on temporary WAT file removal

### DIFF
--- a/circom/src/compilation_user.rs
+++ b/circom/src/compilation_user.rs
@@ -114,7 +114,9 @@ pub fn compile(config: CompilerConfig) -> Result<(), ()> {
             (false, true) => {
                 compiler_interface::write_wasm(&circuit,  &config.js_folder, &config.wasm_name, &config.wat_file)?;
                 let result = wat_to_wasm(&config.wat_file, &config.wasm_file);
-                std::fs::remove_file(&config.wat_file).unwrap();
+                if let Err(err) = std::fs::remove_file(&config.wat_file) {
+                    eprintln!("{}", Colour::Yellow.paint(format!("warning: could not remove temporary WAT file '{}': {}", &config.wat_file, err)));
+                }
                 match result {
                     Result::Err(report) => {
                         Report::print_reports(&[report], &FileLibrary::new());


### PR DESCRIPTION


##  Description
Fixed a potential crash when removing temporary `.wat` files during WASM compilation. The previous implementation used `.unwrap()` which could cause the entire compilation process to panic if file removal failed due to permissions, file locks, or other filesystem issues.

## 🔧 Changes
- **File**: `circom/src/compilation_user.rs`
- **Line**: 117
- **Before**: `std::fs::remove_file(&config.wat_file).unwrap();`
- **After**: Safe removal with warning message instead of panic

