### PR TITLE
Fix typos in comments and docs (no functional changes)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,7 @@
 #### Improvements
 - Adding a specific 64-bit arithmetization for Goldilocks in C++ (not using asm), which dramatically improves witness generation efficiency for this prime.
 - Generation of full C++ code for the arithmatization (for the prime in use) as an alternative to asm code. This is activated with the new --no_asm flag and provides C++ witness generation code which is independent from the architecture being used.
-- Improving the analysis of signal double assigment: branch case no longer causes an error in assignments in different branches.
+- Improving the analysis of signal double assignment: branch case no longer causes an error in assignments in different branches.
 - Improving the generated C++ code by removing unnecessary instructions.
   
 ###Fixed bugs

--- a/code_producers/src/c_elements/bls12377/fr.asm
+++ b/code_producers/src/c_elements/bls12377/fr.asm
@@ -269,7 +269,7 @@ u64toLong_adjust_neg:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= The value
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_toInt:
@@ -8724,7 +8724,7 @@ lnot_retOne:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= 1 if true 0 if false
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_isTrue:

--- a/code_producers/src/c_elements/bls12381/fr.asm
+++ b/code_producers/src/c_elements/bls12381/fr.asm
@@ -269,7 +269,7 @@ u64toLong_adjust_neg:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= The value
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_toInt:
@@ -8724,7 +8724,7 @@ lnot_retOne:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= 1 if true 0 if false
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_isTrue:

--- a/code_producers/src/c_elements/bn128/fr.asm
+++ b/code_producers/src/c_elements/bn128/fr.asm
@@ -269,7 +269,7 @@ u64toLong_adjust_neg:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= The value
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_toInt:
@@ -8724,7 +8724,7 @@ lnot_retOne:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= 1 if true 0 if false
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_isTrue:

--- a/code_producers/src/c_elements/grumpkin/fr.asm
+++ b/code_producers/src/c_elements/grumpkin/fr.asm
@@ -269,7 +269,7 @@ u64toLong_adjust_neg:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= The value
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_toInt:
@@ -8724,7 +8724,7 @@ lnot_retOne:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= 1 if true 0 if false
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_isTrue:

--- a/code_producers/src/c_elements/mod.rs
+++ b/code_producers/src/c_elements/mod.rs
@@ -32,8 +32,8 @@ pub struct CProducer {
     string_table: Vec<String>,
     //New for buses
     pub num_of_bus_instances: usize,  //total number of different bus instances
-    //pub size_of_bus_fields: usize,  //total number of fields in all differen bus intances
-    pub busid_field_info: FieldMap, //for every busId (0..num-1) provides de offset, size, dimensions and busId of each field (0..n-1) in it
+    //pub size_of_bus_fields: usize,  //total number of fields in all different bus instances
+    pub busid_field_info: FieldMap, //for every busId (0..num-1) provides the offset, size, dimensions and busId of each field (0..n-1) in it
     pub no_asm: bool,
 }
 

--- a/code_producers/src/c_elements/pallas/fr.asm
+++ b/code_producers/src/c_elements/pallas/fr.asm
@@ -269,7 +269,7 @@ u64toLong_adjust_neg:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= The value
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_toInt:
@@ -8724,7 +8724,7 @@ lnot_retOne:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= 1 if true 0 if false
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_isTrue:

--- a/code_producers/src/c_elements/secq256r1/fr.asm
+++ b/code_producers/src/c_elements/secq256r1/fr.asm
@@ -269,7 +269,7 @@ u64toLong_adjust_neg:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= The value
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_toInt:
@@ -8807,7 +8807,7 @@ lnot_retOne:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= 1 if true 0 if false
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_isTrue:

--- a/code_producers/src/c_elements/vesta/fr.asm
+++ b/code_producers/src/c_elements/vesta/fr.asm
@@ -269,7 +269,7 @@ u64toLong_adjust_neg:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= The value
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_toInt:
@@ -8724,7 +8724,7 @@ lnot_retOne:
 ; Convert a 64 bit integer to a long format field element
 ; Params:
 ;   rsi <= Pointer to the element
-; Returs:
+; Returns:
 ;   rax <= 1 if true 0 if false
 ;;;;;;;;;;;;;;;;;;;;;;;
 Fr_isTrue:

--- a/code_producers/src/wasm_elements/mod.rs
+++ b/code_producers/src/wasm_elements/mod.rs
@@ -60,8 +60,8 @@ pub struct WASMProducer {
     string_table:  Vec<String>,
     //New for buses
     pub num_of_bus_instances: usize,  //total number of different bus instances
-//    pub size_of_bus_fields: usize,  //total number of fields in all differen bus intances ???
-    pub busid_field_info: FieldMap, //for every busId (0..num-1) provides de offset, the dimensions and size of each field (0..n-1) in it
+//    pub size_of_bus_fields: usize,  //total number of fields in all different bus instances ???
+    pub busid_field_info: FieldMap, //for every busId (0..num-1) provides the offset, the dimensions and size of each field (0..n-1) in it
 }
 
 impl Default for WASMProducer {

--- a/code_producers/src/wasm_elements/wasm_code_generator.rs
+++ b/code_producers/src/wasm_elements/wasm_code_generator.rs
@@ -319,7 +319,7 @@ pub fn generate_data_io_signals_to_info(
                     //do not store code and the first one of lengths (offset + size + length-1(if >0)
                     if s.lengths.len() == 0 { //only offset
                         pos += 4;
-                    } else { // offest + length -1 + size
+                    } else { // offset + length -1 + size
                         pos += s.lengths.len() * 4 + 4;
                     }
 		    if let Some(_) = s.bus_id {

--- a/compiler/src/circuit_design/template.rs
+++ b/compiler/src/circuit_design/template.rs
@@ -270,7 +270,7 @@ impl TemplateCodeInfo {
 		&self.number_of_outputs.to_string()
             ));
 	}
-	// if has no inputs should be runned
+	// if has no inputs should be run
 	if self.number_of_inputs == 0 {
 	    let cmp_call_name = format!("{}_run", self.header);
 	    let cmp_call_arguments = vec![component_offset(), CIRCOM_CALC_WIT.to_string()]; 

--- a/compiler/src/intermediate_representation/call_bucket.rs
+++ b/compiler/src/intermediate_representation/call_bucket.rs
@@ -567,7 +567,7 @@ impl WriteC for CallBucket {
 			    map_prologue.push(format!("{{"));
 			    map_prologue.push(format!("uint map_accesses_aux[{}];",indexes.len().to_string()));	
 			    map_prologue.push(format!("{{"));
-			    //cur_def contains a pointer to the definion of the next acces.
+			    //cur_def contains a pointer to the definition of the next access.
 			    //The first time it is taken from template_ins_2_io_info
 			    map_prologue.push(format!("IOFieldDef *cur_def = &({}->{}[{}].defs[{}]);",
 						      circom_calc_wit(), template_ins_2_io_info(),
@@ -591,7 +591,7 @@ impl WriteC for CallBucket {
 					let (mut index_code, index_exp) = index_list[i].produce_c(producer, parallel);
 					map_prologue.append(&mut index_code);
 					map_prologue.push(format!("map_index_aux[{}]={};",i.to_string(),index_exp));
-					// multiply the offset inthe array by the size of the elements
+					// multiply the offset in the array by the size of the elements
 					map_index = format!("({})*cur_def->lengths[{}]+map_index_aux[{}]",
 							    map_index,(i-1).to_string(),i.to_string());
 				    }

--- a/compiler/src/intermediate_representation/compute_bucket.rs
+++ b/compiler/src/intermediate_representation/compute_bucket.rs
@@ -236,7 +236,7 @@ impl WriteWasm for ComputeBucket {
                             instructions.push(set_local(producer.get_counter_tag()));
                             instructions.push(set_local(producer.get_aux_2_tag()));  // second argument initial position
 			    instructions.push(set_local(producer.get_aux_1_tag()));  // first argument initial position
-			    instructions.push(set_local(producer.get_aux_0_tag()));  // resut position
+			    instructions.push(set_local(producer.get_aux_0_tag()));  // result position
                             instructions.push(add_block());
                             instructions.push(add_loop());
                             instructions.push(get_local(producer.get_aux_0_tag()));

--- a/compiler/src/intermediate_representation/load_bucket.rs
+++ b/compiler/src/intermediate_representation/load_bucket.rs
@@ -269,7 +269,7 @@ impl WriteC for LoadBucket {
 					     template_id_in_component(sub_component_pos_in_memory.clone()),
 					     signal_code.to_string());
 	        if indexes.len() > 0 {
-		    //cur_def contains a string that goes to the definion of the next acces.
+		    //cur_def contains a string that goes to the definition of the next access.
 		    //The first time it is taken from template_ins_2_io_info
 		    let mut cur_def = format!("{}->{}[{}].defs[{}]",
 					    circom_calc_wit(), template_ins_2_io_info(),

--- a/compiler/src/intermediate_representation/store_bucket.rs
+++ b/compiler/src/intermediate_representation/store_bucket.rs
@@ -508,7 +508,7 @@ impl WriteC for StoreBucket {
 	            map_prologue.push(format!("{{"));
 		    map_prologue.push(format!("uint map_accesses_aux[{}];",indexes.len().to_string()));
 	            map_prologue.push(format!("{{"));		    
-		    //cur_def contains a pointer to the definion of the next acces.
+		    //cur_def contains a pointer to the definition of the next access.
 		    //The first time it is taken from template_ins_2_io_info
 		    map_prologue.push(format!("IOFieldDef *cur_def = &({}->{}[{}].defs[{}]);",
 					    circom_calc_wit(), template_ins_2_io_info(),
@@ -597,7 +597,7 @@ impl WriteC for StoreBucket {
                 }
             }
         };
-	//keep dest_index in an auxiliar if parallel and out put
+	//keep dest_index in an auxiliary if parallel and out put
 	if let AddressType::Signal = &self.dest_address_type {
 	    if parallel.unwrap() && self.dest_is_output {
             prologue.push(format!("{{")); //open block 1 when parallel and Signal 
@@ -634,7 +634,7 @@ impl WriteC for StoreBucket {
 		    prologue.push(format!("{}->componentMemory[{}].cvs[{}+i].notify_all();",CIRCOM_CALC_WIT,CTX_INDEX,aux_dest_index.clone()));
 		    prologue.push(format!("}}")); // close block 4
 		    prologue.push(format!("}}")); // close block 3
-		    prologue.push(format!("}}")); // add a close for block 1 (as it's oppened)
+		    prologue.push(format!("}}")); // add a close for block 1 (as it's opened)
 		}
 	    }
         } else {

--- a/compiler/src/intermediate_representation/translate.rs
+++ b/compiler/src/intermediate_representation/translate.rs
@@ -1137,7 +1137,7 @@ impl ProcessedSymbol {
             match acc {
 
                 ArrayAccess(exp) => {
-                    // we need to study all possible sizes and lenghts
+                    // we need to study all possible sizes and lengths
                     let mut index = 0;
                     for possible_length in &mut possible_status.possible_lengths{
                         let aux_length = possible_length.pop();
@@ -1155,7 +1155,7 @@ impl ProcessedSymbol {
                         let possible_cmp_id = state.component_to_instance.get(&symbol_name).unwrap().clone();
                         let mut is_first = true;
 
-                        // We init the possible lenghts and sizes
+                        // We init the possible lengths and sizes
                         possible_status.possible_lengths = Vec::new();
                         possible_status.possible_sizes = Vec::new();
                         possible_status.possible_cmp_id = Vec::new();

--- a/constraint_generation/src/environment_utils/bus_representation.rs
+++ b/constraint_generation/src/environment_utils/bus_representation.rs
@@ -186,7 +186,7 @@ impl BusRepresentation {
         is_input: bool,
         conditions_assignment: &AssignmentState
     ) -> Result<(), MemoryError> {
-            // TODO: move to auxiliar function to do not repeat effort
+            // TODO: move to auxiliary function to do not repeat effort
             // We update the has_assignment value if not tag and not empty
             let has_assignment = match assigned_value{
                 FoldedArgument::Signal(dimensions)=>{

--- a/constraint_generation/src/environment_utils/component_representation.rs
+++ b/constraint_generation/src/environment_utils/component_representation.rs
@@ -180,7 +180,7 @@ impl ComponentRepresentation {
                     &mut initial_value_bus,
                     bus_node,
                     scheme,
-                    false // it is not initialized at the begining
+                    false // it is not initialized at the beginning
                 )?;
                 let bus_slice = BusSlice::new_with_route(route, &initial_value_bus);
                 let bus_slice_size = BusSlice::get_number_of_cells(&bus_slice);
@@ -220,7 +220,7 @@ impl ComponentRepresentation {
                     &mut initial_value_bus,
                     bus_node,
                     scheme,
-                    true // the outputs of the component are initialized at the begining
+                    true // the outputs of the component are initialized at the beginning
                 )?;
                 let bus_slice = BusSlice::new_with_route(route, &initial_value_bus);
     

--- a/constraint_generation/src/execute.rs
+++ b/constraint_generation/src/execute.rs
@@ -453,7 +453,7 @@ fn execute_statement(
                     }
 
                     if !needs_double_arrow.is_empty() && flags.inspect{
-                        // in case we can subsitute the complete expression to ==>
+                        // in case we can substitute the complete expression to ==>
                         if needs_double_arrow.len() == AExpressionSlice::get_number_of_cells(&constrained.right){
                             let err : Result<(),ExecutionWarning> = 
                                 Result::Err(ExecutionWarning::CanBeQuadraticConstraintSingle());
@@ -1341,7 +1341,7 @@ fn execute_bus_declaration(
 }
 
 /*
-    In case the assigment could be a constraint generator the returned value is the constraint
+    In case the assignment could be a constraint generator the returned value is the constraint
     that will be created
 */
 enum ExecutedStructure<'a>{
@@ -1967,7 +1967,7 @@ fn perform_assign(
         }
 
         if FoldedValue::valid_bus_node_pointer(&r_folded){
-            // in this case we are performing an assigment of the type in the node_pointer
+            // in this case we are performing an assignment of the type in the node_pointer
             // to the bus in the left
             
             let bus_pointer = r_folded.bus_node_pointer.unwrap();

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -40,7 +40,7 @@ The compiler outputs the representation of the circuit as constraints and everyt
 
 ## circomlib
 
-With `circom`, it is possible to create large circuits by combining smaller generic circuits called `templates`. The `circomlib` is a library of `circom` templates that contains hundreds of circuits such as comparators, hash functions, digital signatures, binary and decimal convertors and many more. You can also create your custom templates, but before start coding, we recommend you to take a look at our already created templates.
+With `circom`, it is possible to create large circuits by combining smaller generic circuits called `templates`. The `circomlib` is a library of `circom` templates that contains hundreds of circuits such as comparators, hash functions, digital signatures, binary and decimal converters and many more. You can also create your custom templates, but before start coding, we recommend you to take a look at our already created templates.
 
 The package already contains tests for circuits available in the `circomlib`.
 The package also installs the npm packages `circomlibjs`, `circom_tester` and `ffjavascript` as dependencies.

--- a/program_structure/src/abstract_syntax_tree/ast_shortcuts.rs
+++ b/program_structure/src/abstract_syntax_tree/ast_shortcuts.rs
@@ -71,7 +71,7 @@ pub fn split_declaration_into_single_nodes(
         // For the variables, we need to initialize them to 0 in case:
         //     - They are not initialized to other value
         //     - They are arrays (and maybe not all positions are initialized)
-        // in case flag no_init we do not perfom these changes
+        // in case flag no_init we do not perform these changes
 
         if xtype == Var && (possible_init.is_none() || dimensions.len() > 0) && !flag_no_init{
             let mut value = Expression:: Number(meta.clone(), BigInt::from(0));

--- a/type_analysis/src/analyzers/unknown_known_analysis.rs
+++ b/type_analysis/src/analyzers/unknown_known_analysis.rs
@@ -549,7 +549,7 @@ fn add_report(
     let mut report = Report::error("Typing error found".to_string(), error_code);
     let location = generate_file_location(meta.start, meta.end);
     let message = match error_code {
-        UnknownTemplateAssignment => "Assigments to signals within an unknown access to an array of components are not allowed".to_string(),
+        UnknownTemplateAssignment => "Assignments to signals within an unknown access to an array of components are not allowed".to_string(),
         UnknownBus => "Parameters of a bus must be known during the constraint generation phase".to_string(),
         UnknownDimension => "The length of every array must be known during the constraint generation phase".to_string(),
         UnknownTemplate => "Every component instantiation must be resolved during the constraint generation phase. This component declaration uses a value that can be unknown during the constraint generation phase.".to_string(),


### PR DESCRIPTION
### Summary
Fix spelling mistakes across comments and documentation. No functional or API changes.

### What’s changed
- Rust comments and messages:
  - `constraint_generation`, `compiler` (IR buckets), `program_structure`, `type_analysis`
  - Examples: “subsitute”→“substitute”, “assigment”→“assignment”, “auxiliar”→“auxiliary”, “lenghts”→“lengths”, “perfom”→“perform”, “oppened”→“opened”, etc.
- Docs:
  - `RELEASES.md`: “assigment”→“assignment”
  - `mkdocs/docs/index.md`: “convertors”→“converters”
- C/ASM generators (comments only):
  - `code_producers/src/wasm_elements/*.rs`, `code_producers/src/c_elements/*.rs`: “differen/intances/de”→“different/instances/the”
  - `code_producers/src/c_elements/*/fr.asm` (comments): “Returs”, “seconf”, “substract*”, “comare”→“Returns”, “second”, “subtract*”, “compare”

### Explicitly not changed
- Correct/intentional terms: `wast` (crate name), `Groth16` (surname), `Connexion`/`BusConnexion` naming.
- Identifiers that would require refactors (e.g., `signal_to_ocurrences`) to avoid breaking changes.

### Validation
- Build and lints pass locally.
- Only comments, doc strings, and Markdown were edited.