### PR TITLE
fix: use BigInt::from(-1) instead of invalid -1 % field

### DIFF
--- a/circom_algebra/src/algebra.rs
+++ b/circom_algebra/src/algebra.rs
@@ -898,7 +898,7 @@ impl<C: Default + Clone + Display + Hash + Eq> Substitution<C> {
         let symbol = substitution.from;
         let mut coefficients = substitution.to;
         ArithmeticExpression::initialize_hashmap_for_expression(&mut coefficients);
-        coefficients.insert(symbol, BigInt::from(-1 % field));
+        coefficients.insert(symbol, BigInt::from(-1));
         let arith = ArithmeticExpression::Linear { coefficients };
         ArithmeticExpression::transform_expression_to_constraint_form(arith, field).unwrap()
     }


### PR DESCRIPTION
- Replace non-compilable BigInt construction BigInt::from(-1 % field) in Substitution::substitution_into_constraint with BigInt::from(-1).
- Aligns with existing modular handling across the codebase, where reduction happens in modular_arithmetic operations.
- Grepped the repository; no other analogous invalid usages found.