### PR TITLE
docs: fix `==>` → `<==` in Circom

### DIFF
--- a/mkdocs/docs/circom-language/templates-and-components.md
+++ b/mkdocs/docs/circom-language/templates-and-components.md
@@ -88,7 +88,7 @@ template Main() {
    signal output out;
    component c = Internal ();
    c.in[0] <== in[0];
-   c.out ==> out;  // c.in[1] is not assigned yet
+   c.out <== out;  // c.in[1] is not assigned yet
    c.in[1] <== in[1];  // this line should be placed before calling c.out
 }
 


### PR DESCRIPTION
changed the wrong arrow to `<==` so it compiles correctly.