### PR TITLE
Use write_all for fixed-size payloads in R1CS writer

### DIFF
--- a/constraint_writers/src/r1cs_writer.rs
+++ b/constraint_writers/src/r1cs_writer.rs
@@ -382,7 +382,7 @@ impl CustomGatesUsedSection {
             for parameter in custom_gate_parameters {
                 let (parameter_stream, parameter_size) = bigint_as_bytes(&parameter, self.field_size);
                 self.size += parameter_size;
-                self.writer.write(&parameter_stream).map_err(|_err| {})?;
+                self.writer.write_all(&parameter_stream).map_err(|_err| {})?;
                 //self.writer.flush().map_err(|_err| {})?;
             }
         }
@@ -432,7 +432,7 @@ impl CustomGatesAppliedSection {
             for signal in custom_gate_signals {
                 let (signal_stream, signal_size) = bigint_as_bytes(&BigInt::from(signal), 8);
                 self.size += signal_size;
-                self.writer.write(&signal_stream).map_err(|_err| {})?;
+                self.writer.write_all(&signal_stream).map_err(|_err| {})?;
                 //self.writer.flush().map_err(|_err| {})?;
             }
         }


### PR DESCRIPTION
This change replaces two calls to write(...) with write_all(...) when writing fixed-size payloads:
- CustomGatesUsedSection: parameters (field_size bytes each)
- CustomGatesAppliedSection: signal indices (8 bytes each)

The paired reader uses read_exact for these fields, so write(...) risks short writes and corrupting the bytestream. Using write_all(...) guarantees the full buffer is written, ensuring consistency with the reader and with the rest of the module, which already uses write_all for fixed-size data.