### PR TITLE
fix: correct contractions in comments

### DIFF
--- a/compiler/src/intermediate_representation/translate.rs
+++ b/compiler/src/intermediate_representation/translate.rs
@@ -25,7 +25,7 @@ pub struct OutBoundsCheck{
 pub struct SymbolInfo {
     access_instruction: InstructionPointer,
     dimensions: Vec<Length>,
-    size: usize, // needed, in case it is a bus to dont have to compute it again
+    size: usize, // needed, in case it is a bus to don't have to compute it again
     is_component: bool,
     is_bus: bool,
     bus_id: Option<usize>,

--- a/constraint_generation/src/execute.rs
+++ b/constraint_generation/src/execute.rs
@@ -2665,7 +2665,7 @@ fn execute_conditional_statement(
         runtime.block_type = BlockType::Unknown;
         // TODO: here instead of executing both branches what we do is to store the values
         // that we assign in each one of the branches and assign later: if we assign in both 
-        // of them a signal we return an error. If we assign in just one then we dont return error
+        // of them a signal we return an error. If we assign in just one then we don't return error
         // (maybe a warning indicating that the variable may not get assigned in the if)
         
         


### PR DESCRIPTION
## Description
Fixed grammatical errors in code comments.

⚠️ **Note:** Comment-only changes. No functional code modified. This is a minor documentation improvement.

## Changes
- Fixed `dont` → `don't` in translator comment
- Fixed `dont` → `don't` in executor comment

## Files Modified
- compiler/src/intermediate_representation/translate.rs
- constraint_generation/src/execute.rs

## Impact
- No functional changes
- Comment clarity improvement only