### PR TITLE
Define Darwin GMP limb flag for witness builds

### DIFF
--- a/code_producers/src/c_elements/c_code_generator.rs
+++ b/code_producers/src/c_elements/c_code_generator.rs
@@ -1334,4 +1334,39 @@ mod tests {
         let _rc = generate_c_file(pathc, &producer);
         assert!(true);
     }
+
+    #[test]
+    fn generated_makefiles_define_long_long_gmp_limbs() {
+        let path = "../target/code_generator_makefile_test";
+        let _ = std::fs::remove_dir_all(path);
+        std::fs::create_dir(path).unwrap();
+
+        for (name, no_asm, prime) in [
+            ("asm", false, "bn128"),
+            ("no_asm", true, "bn128"),
+            ("goldilocks", false, "goldilocks"),
+        ] {
+            let mut producer = create_producer();
+            producer.no_asm = no_asm;
+            producer.prime_str = prime.to_string();
+            let c_folder = std::path::PathBuf::from(format!("{}/{}", path, name));
+            std::fs::create_dir(&c_folder).unwrap();
+            generate_make_file(&c_folder, "test_circuit", &producer).unwrap();
+
+            let makefile = std::fs::read_to_string(c_folder.join("Makefile")).unwrap();
+            assert!(makefile.contains(
+                "ifeq ($(shell uname),Darwin)\n\tGMP_CFLAGS=-D_LONG_LONG_LIMB"
+            ));
+            if producer.no_asm {
+                assert!(makefile
+                    .contains("\t$(CC) -Wno-address-of-packed-member -c $< $(CFLAGS) $(GMP_CFLAGS)"));
+            } else {
+                assert!(makefile.contains("\t$(CC) -c $< $(CFLAGS) $(GMP_CFLAGS)"));
+            }
+            if producer.prime_str == "goldilocks" {
+                assert!(makefile
+                    .contains("\t$(CC) -o json2bin64 json2bin64.cpp $(GMP_CFLAGS) -lgmp"));
+            }
+        }
+    }
 }

--- a/code_producers/src/c_elements/c_code_generator.rs
+++ b/code_producers/src/c_elements/c_code_generator.rs
@@ -1336,7 +1336,7 @@ mod tests {
     }
 
     #[test]
-    fn generated_makefiles_define_long_long_gmp_limbs() {
+    fn generated_makefiles_pass_darwin_gmp_limb_flag() {
         let path = "../target/code_generator_makefile_test";
         let _ = std::fs::remove_dir_all(path);
         std::fs::create_dir(path).unwrap();

--- a/code_producers/src/c_elements/common/makefile
+++ b/code_producers/src/c_elements/common/makefile
@@ -1,9 +1,11 @@
 CC=g++
 CFLAGS=-std=c++11 -O3 -I.
+GMP_CFLAGS=
 DEPS_HPP = circom.hpp calcwit.hpp fr.hpp
 DEPS_O = main.o calcwit.o fr.o fr_asm.o
 
 ifeq ($(shell uname),Darwin)
+	GMP_CFLAGS=-D_LONG_LONG_LIMB
 	NASM=nasm -fmacho64 --prefix _
 endif
 ifeq ($(shell uname),Linux)
@@ -13,7 +15,7 @@ endif
 all: {{run_name}}
 	
 %.o: %.cpp $(DEPS_HPP)
-	$(CC) -c $< $(CFLAGS)
+	$(CC) -c $< $(CFLAGS) $(GMP_CFLAGS)
 
 fr_asm.o: fr.asm
 	$(NASM) fr.asm -o fr_asm.o

--- a/code_producers/src/c_elements/common64/makefile
+++ b/code_producers/src/c_elements/common64/makefile
@@ -1,17 +1,22 @@
 CC=g++
 CFLAGS=-std=c++11 -O3 -I.
+GMP_CFLAGS=
 EXTRA_FILES = json2bin64.cpp
 DEPS_HPP = circom.hpp calcwit.hpp fr.hpp
 DEPS_CPP := $(filter-out $(EXTRA_FILES), $(wildcard *.cpp))
 DEPS_O := $(patsubst %.cpp,%.o,$(DEPS_CPP))
 
+ifeq ($(shell uname),Darwin)
+	GMP_CFLAGS=-D_LONG_LONG_LIMB
+endif
+
 all: {{run_name}}
 
 %.o: %.cpp $(DEPS_HPP)
-	$(CC) -c $< $(CFLAGS)
+	$(CC) -c $< $(CFLAGS) $(GMP_CFLAGS)
 
 {{run_name}}: $(DEPS_O) {{run_name}}.o
 	$(CC) -o {{run_name}} $(DEPS_O) -lgmp {{#if has_parallelism}}-pthread{{/if}}
 
 json2bin64: json2bin64.cpp
-	$(CC) -o json2bin64 json2bin64.cpp -lgmp 
+	$(CC) -o json2bin64 json2bin64.cpp $(GMP_CFLAGS) -lgmp

--- a/code_producers/src/c_elements/generic/makefile
+++ b/code_producers/src/c_elements/generic/makefile
@@ -1,12 +1,17 @@
 CC=g++
 CFLAGS=-std=c++11 -O3 -I.
+GMP_CFLAGS=
 DEPS_HPP = circom.hpp calcwit.hpp fr.hpp
 DEPS_O = main.o calcwit.o fr.o 
+
+ifeq ($(shell uname),Darwin)
+	GMP_CFLAGS=-D_LONG_LONG_LIMB
+endif
 
 all: {{run_name}}
 
 %.o: %.cpp $(DEPS_HPP)
-	$(CC) -Wno-address-of-packed-member -c $< $(CFLAGS)
+	$(CC) -Wno-address-of-packed-member -c $< $(CFLAGS) $(GMP_CFLAGS)
 
 {{run_name}}: $(DEPS_O) {{run_name}}.o
 	$(CC) -o {{run_name}} *.o -lgmp {{#if has_parallelism}}-pthread{{/if}}


### PR DESCRIPTION
## Summary
- set `-D_LONG_LONG_LIMB` for generated C++ witness builds on Darwin
- pass the GMP flag through all generated C++ object compile rules
- cover the Goldilocks `json2bin64` compile path and add generated Makefile regression coverage

## Why
On Darwin, GMP limb types can require `_LONG_LONG_LIMB` for generated witness C++ to agree with GMP's `mp_limb_t` layout. Linux and other platforms keep an empty flag.

Addresses #351.

## Test
- `cargo test -p code_producers -- --test-threads=1`
- `cargo build -p circom`
- macOS arm64 generated witness compile proof: upstream `master` fails with GMP `uint64_t *` to `mp_ptr` conversion errors, while this branch builds the generated witness successfully: https://github.com/Kuhai9801/circom/actions/runs/26813644848