### PR TITLE
fix: make Tree lifetime explicit

### DIFF
--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -31,7 +31,7 @@ pub struct Tree<'a> {
 }
 
 impl<'a> Tree<'a> {
-    pub fn new(dag: &DAG) -> Tree {
+    pub fn new(dag: &DAG) -> Tree<'_> {
         let constants = UsefulConstants::new(&dag.prime);
         let field = constants.get_p().clone();
         let root = dag.get_main().unwrap();


### PR DESCRIPTION
Fixes a Rust mismatched lifetime syntax warning in `dag::Tree::new`.

This change makes the elided lifetime explicit in the return type without changing behavior.